### PR TITLE
[Discover] Fix `breakdownField` in `getDefaultAppState`

### DIFF
--- a/src/plugins/discover/public/__mocks__/services.ts
+++ b/src/plugins/discover/public/__mocks__/services.ts
@@ -14,6 +14,7 @@ import { uiActionsPluginMock } from '@kbn/ui-actions-plugin/public/mocks';
 import { expressionsPluginMock } from '@kbn/expressions-plugin/public/mocks';
 import { savedSearchPluginMock } from '@kbn/saved-search-plugin/public/mocks';
 import {
+  analyticsServiceMock,
   chromeServiceMock,
   coreMock,
   docLinksServiceMock,
@@ -149,6 +150,7 @@ export function createDiscoverServicesMock(): DiscoverServices {
   corePluginMock.chrome.getActiveSolutionNavId$.mockReturnValue(new BehaviorSubject(null));
 
   return {
+    analytics: analyticsServiceMock.createAnalyticsServiceStart(),
     application: corePluginMock.application,
     core: corePluginMock,
     charts: chartPluginMock.createSetupContract(),

--- a/src/plugins/discover/public/application/main/components/layout/use_discover_histogram.test.tsx
+++ b/src/plugins/discover/public/application/main/components/layout/use_discover_histogram.test.tsx
@@ -7,506 +7,510 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import React, { ReactElement } from 'react';
-import { AggregateQuery, Query } from '@kbn/es-query';
-import { act, renderHook, WrapperComponent } from '@testing-library/react-hooks';
-import { BehaviorSubject, Subject } from 'rxjs';
-import { FetchStatus } from '../../../types';
-import type { DiscoverStateContainer } from '../../state_management/discover_state';
-import { dataPluginMock } from '@kbn/data-plugin/public/mocks';
-import { useDiscoverHistogram, UseDiscoverHistogramProps } from './use_discover_histogram';
-import { setTimeout } from 'timers/promises';
-import { getDiscoverStateMock } from '../../../../__mocks__/discover_state.mock';
-import { DiscoverMainProvider } from '../../state_management/discover_state_provider';
-import { RequestAdapter } from '@kbn/inspector-plugin/public';
-import {
-  UnifiedHistogramFetchStatus,
-  UnifiedHistogramState,
-} from '@kbn/unified-histogram-plugin/public';
-import { createMockUnifiedHistogramApi } from '@kbn/unified-histogram-plugin/public/mocks';
-import { checkHitCount, sendErrorTo } from '../../hooks/use_saved_search_messages';
-import type { InspectorAdapters } from '../../hooks/use_inspector';
-import { UnifiedHistogramCustomization } from '../../../../customizations/customization_types/histogram_customization';
-import { useDiscoverCustomization } from '../../../../customizations';
-import { DiscoverCustomizationId } from '../../../../customizations/customization_service';
-
-const mockData = dataPluginMock.createStartContract();
-let mockQueryState = {
-  query: {
-    query: 'query',
-    language: 'kuery',
-  } as Query | AggregateQuery,
-  filters: [],
-  time: {
-    from: 'now-15m',
-    to: 'now',
-  },
-};
-
-mockData.query.getState = () => mockQueryState;
-
-jest.mock('../../../../hooks/use_discover_services', () => {
-  const originalModule = jest.requireActual('../../../../hooks/use_discover_services');
-  return {
-    ...originalModule,
-    useDiscoverServices: () => ({ data: mockData }),
-  };
-});
-
-jest.mock('@kbn/unified-field-list/src/hooks/use_query_subscriber', () => {
-  const originalModule = jest.requireActual(
-    '@kbn/unified-field-list/src/hooks/use_query_subscriber'
-  );
-  return {
-    ...originalModule,
-    useQuerySubscriber: jest.fn(() => ({
-      ...mockQueryState,
-      fromDate: 'now-15m',
-      toDate: 'now',
-    })),
-  };
-});
-
-jest.mock('../../hooks/use_saved_search_messages', () => {
-  const originalModule = jest.requireActual('../../hooks/use_saved_search_messages');
-  return {
-    ...originalModule,
-    checkHitCount: jest.fn(originalModule.checkHitCount),
-    sendErrorTo: jest.fn(originalModule.sendErrorTo),
-  };
-});
-jest.mock('../../../../customizations', () => ({
-  ...jest.requireActual('../../../../customizations'),
-  useDiscoverCustomization: jest.fn(),
-}));
-
-let mockUseCustomizations = false;
-
-const mockHistogramCustomization: UnifiedHistogramCustomization = {
-  id: 'unified_histogram',
-  onFilter: jest.fn(),
-  onBrushEnd: jest.fn(),
-  withDefaultActions: true,
-};
-
-const mockCheckHitCount = checkHitCount as jest.MockedFunction<typeof checkHitCount>;
-
 describe('useDiscoverHistogram', () => {
-  const getStateContainer = () => {
-    const stateContainer = getDiscoverStateMock({ isTimeBased: true });
-    stateContainer.appState.update({
-      interval: 'auto',
-      hideChart: false,
-      breakdownField: 'extension',
-    });
-    const appState = stateContainer.appState;
-    const wrappedStateContainer = Object.create(appState);
-    wrappedStateContainer.update = jest.fn((newState) => appState.update(newState));
-    stateContainer.appState = wrappedStateContainer;
-    return stateContainer;
-  };
-
-  const renderUseDiscoverHistogram = async ({
-    stateContainer = getStateContainer(),
-    inspectorAdapters = { requests: new RequestAdapter() },
-    hideChart = false,
-  }: {
-    stateContainer?: DiscoverStateContainer;
-    inspectorAdapters?: InspectorAdapters;
-    hideChart?: boolean;
-  } = {}) => {
-    const initialProps = {
-      stateContainer,
-      inspectorAdapters,
-      hideChart,
-    };
-
-    const Wrapper: WrapperComponent<React.PropsWithChildren<UseDiscoverHistogramProps>> = ({
-      children,
-    }) => (
-      <DiscoverMainProvider value={stateContainer}>{children as ReactElement}</DiscoverMainProvider>
-    );
-
-    const hook = renderHook(
-      (props: UseDiscoverHistogramProps) => {
-        return useDiscoverHistogram(props);
-      },
-      {
-        wrapper: Wrapper,
-        initialProps,
-      }
-    );
-
-    await act(() => setTimeout(0));
-
-    return { hook, initialProps };
-  };
-
-  beforeEach(() => {
-    mockUseCustomizations = false;
-    jest.clearAllMocks();
-
-    (useDiscoverCustomization as jest.Mock).mockImplementation((id: DiscoverCustomizationId) => {
-      if (!mockUseCustomizations) {
-        return undefined;
-      }
-      switch (id) {
-        case 'unified_histogram':
-          return mockHistogramCustomization;
-        default:
-          throw new Error(`Unknown customization id: ${id}`);
-      }
-    });
-  });
-
-  describe('initialization', () => {
-    it('should return the expected parameters from getCreationOptions', async () => {
-      const { hook } = await renderUseDiscoverHistogram();
-      const params = hook.result.current.getCreationOptions();
-      expect(params?.localStorageKeyPrefix).toBe('discover');
-      expect(params?.disableAutoFetching).toBe(true);
-      expect(Object.keys(params?.initialState ?? {})).toEqual([
-        'chartHidden',
-        'timeInterval',
-        'breakdownField',
-        'totalHitsStatus',
-        'totalHitsResult',
-      ]);
-    });
-
-    it('should return the isChartLoading params for ES|QL mode', async () => {
-      const stateContainer = getStateContainer();
-      stateContainer.appState.update({ query: { esql: 'from *' } });
-      const { hook } = await renderUseDiscoverHistogram();
-      const isChartLoading = hook.result.current.isChartLoading;
-      expect(isChartLoading).toBe(false);
-    });
-  });
-
-  describe('state', () => {
-    beforeEach(() => {
-      mockCheckHitCount.mockClear();
-    });
-
-    it('should subscribe to state changes', async () => {
-      const { hook } = await renderUseDiscoverHistogram();
-      const api = createMockUnifiedHistogramApi();
-      jest.spyOn(api.state$, 'subscribe');
-      act(() => {
-        hook.result.current.ref(api);
-      });
-      expect(api.state$.subscribe).toHaveBeenCalledTimes(2);
-    });
-
-    it('should sync Unified Histogram state with the state container', async () => {
-      const stateContainer = getStateContainer();
-      const inspectorAdapters = { requests: new RequestAdapter(), lensRequests: undefined };
-      const { hook } = await renderUseDiscoverHistogram({ stateContainer, inspectorAdapters });
-      const lensRequestAdapter = new RequestAdapter();
-      const state = {
-        timeInterval: '1m',
-        chartHidden: true,
-        breakdownField: 'test',
-        totalHitsStatus: UnifiedHistogramFetchStatus.loading,
-        totalHitsResult: undefined,
-      } as unknown as UnifiedHistogramState;
-      const api = createMockUnifiedHistogramApi();
-      api.state$ = new BehaviorSubject({ ...state, lensRequestAdapter });
-      act(() => {
-        hook.result.current.ref(api);
-      });
-      expect(inspectorAdapters.lensRequests).toBe(lensRequestAdapter);
-      expect(stateContainer.appState.update).toHaveBeenCalledWith({
-        interval: state.timeInterval,
-        hideChart: state.chartHidden,
-        breakdownField: state.breakdownField,
-      });
-    });
-
-    it('should not sync Unified Histogram state with the state container if there are no changes', async () => {
-      const stateContainer = getStateContainer();
-      const { hook } = await renderUseDiscoverHistogram({ stateContainer });
-      const containerState = stateContainer.appState.getState();
-      const state = {
-        timeInterval: containerState.interval,
-        chartHidden: containerState.hideChart,
-        breakdownField: containerState.breakdownField,
-        totalHitsStatus: UnifiedHistogramFetchStatus.loading,
-        totalHitsResult: undefined,
-      } as unknown as UnifiedHistogramState;
-      const api = createMockUnifiedHistogramApi();
-      api.state$ = new BehaviorSubject(state);
-      act(() => {
-        hook.result.current.ref(api);
-      });
-      expect(stateContainer.appState.update).not.toHaveBeenCalled();
-    });
-
-    it('should sync the state container state with Unified Histogram', async () => {
-      const stateContainer = getStateContainer();
-      const { hook } = await renderUseDiscoverHistogram({ stateContainer });
-      const api = createMockUnifiedHistogramApi();
-      let params: Partial<UnifiedHistogramState> = {};
-      api.setTotalHits = jest.fn((p) => {
-        params = { ...params, ...p };
-      });
-      api.setChartHidden = jest.fn((chartHidden) => {
-        params = { ...params, chartHidden };
-      });
-      api.setTimeInterval = jest.fn((timeInterval) => {
-        params = { ...params, timeInterval };
-      });
-      api.setBreakdownField = jest.fn((breakdownField) => {
-        params = { ...params, breakdownField };
-      });
-      act(() => {
-        hook.result.current.ref(api);
-      });
-      stateContainer.appState.update({ hideChart: true, interval: '1m', breakdownField: 'test' });
-      expect(api.setTotalHits).not.toHaveBeenCalled();
-      expect(api.setChartHidden).toHaveBeenCalled();
-      expect(api.setTimeInterval).toHaveBeenCalled();
-      expect(api.setBreakdownField).toHaveBeenCalled();
-      expect(Object.keys(params ?? {})).toEqual(['breakdownField', 'timeInterval', 'chartHidden']);
-    });
-
-    it('should exclude totalHitsStatus and totalHitsResult from Unified Histogram state updates', async () => {
-      const stateContainer = getStateContainer();
-      const { hook } = await renderUseDiscoverHistogram({ stateContainer });
-      const containerState = stateContainer.appState.getState();
-      const state = {
-        timeInterval: containerState.interval,
-        chartHidden: containerState.hideChart,
-        breakdownField: containerState.breakdownField,
-        totalHitsStatus: UnifiedHistogramFetchStatus.loading,
-        totalHitsResult: undefined,
-      } as unknown as UnifiedHistogramState;
-      const api = createMockUnifiedHistogramApi();
-      let params: Partial<UnifiedHistogramState> = {};
-      api.setChartHidden = jest.fn((chartHidden) => {
-        params = { ...params, chartHidden };
-      });
-      const subject$ = new BehaviorSubject(state);
-      api.state$ = subject$;
-      act(() => {
-        hook.result.current.ref(api);
-      });
-      stateContainer.appState.update({ hideChart: true });
-      expect(Object.keys(params ?? {})).toEqual(['chartHidden']);
-      params = {};
-      stateContainer.appState.update({ hideChart: false });
-      act(() => {
-        subject$.next({
-          ...state,
-          totalHitsStatus: UnifiedHistogramFetchStatus.complete,
-          totalHitsResult: 100,
-        });
-      });
-      expect(Object.keys(params ?? {})).toEqual(['chartHidden']);
-    });
-
-    it('should update total hits when the total hits state changes', async () => {
-      const stateContainer = getStateContainer();
-      const { hook } = await renderUseDiscoverHistogram({ stateContainer });
-      const containerState = stateContainer.appState.getState();
-      const state = {
-        timeInterval: containerState.interval,
-        chartHidden: containerState.hideChart,
-        breakdownField: containerState.breakdownField,
-        totalHitsStatus: UnifiedHistogramFetchStatus.loading,
-        totalHitsResult: undefined,
-      } as unknown as UnifiedHistogramState;
-      const api = createMockUnifiedHistogramApi();
-      api.state$ = new BehaviorSubject({
-        ...state,
-        totalHitsStatus: UnifiedHistogramFetchStatus.complete,
-        totalHitsResult: 100,
-      });
-      expect(stateContainer.dataState.data$.totalHits$.value).not.toEqual({
-        fetchStatus: FetchStatus.COMPLETE,
-        result: 100,
-      });
-      act(() => {
-        hook.result.current.ref(api);
-      });
-      expect(stateContainer.dataState.data$.totalHits$.value).toEqual({
-        fetchStatus: FetchStatus.COMPLETE,
-        result: 100,
-      });
-      expect(mockCheckHitCount).toHaveBeenCalledWith(stateContainer.dataState.data$.main$, 100);
-    });
-
-    it('should not update total hits when the total hits state changes to an error', async () => {
-      mockQueryState = {
-        query: {
-          query: 'query',
-          language: 'kuery',
-        } as Query | AggregateQuery,
-        filters: [],
-        time: {
-          from: 'now-15m',
-          to: 'now',
-        },
-      };
-
-      mockData.query.getState = () => mockQueryState;
-      const stateContainer = getStateContainer();
-      const { hook } = await renderUseDiscoverHistogram({ stateContainer });
-      const containerState = stateContainer.appState.getState();
-      const error = new Error('test');
-      const state = {
-        timeInterval: containerState.interval,
-        chartHidden: containerState.hideChart,
-        breakdownField: containerState.breakdownField,
-        totalHitsStatus: UnifiedHistogramFetchStatus.loading,
-        totalHitsResult: undefined,
-      } as unknown as UnifiedHistogramState;
-      const api = createMockUnifiedHistogramApi();
-      api.state$ = new BehaviorSubject({
-        ...state,
-        totalHitsStatus: UnifiedHistogramFetchStatus.error,
-        totalHitsResult: error,
-      });
-      expect(stateContainer.dataState.data$.totalHits$.value).not.toEqual({
-        fetchStatus: FetchStatus.ERROR,
-        error,
-      });
-      act(() => {
-        hook.result.current.ref(api);
-      });
-      expect(sendErrorTo).toHaveBeenCalledWith(stateContainer.dataState.data$.totalHits$);
-      expect(stateContainer.dataState.data$.totalHits$.value).toEqual({
-        fetchStatus: FetchStatus.ERROR,
-        error,
-      });
-      expect(mockCheckHitCount).not.toHaveBeenCalled();
-    });
-
-    it('should set isChartLoading to true for fetch start', async () => {
-      const fetch$ = new Subject<{
-        options: {
-          reset: boolean;
-          fetchMore: boolean;
-        };
-        searchSessionId: string;
-      }>();
-      const stateContainer = getStateContainer();
-      stateContainer.appState.update({ query: { esql: 'from *' } });
-      stateContainer.dataState.fetch$ = fetch$;
-      const { hook } = await renderUseDiscoverHistogram({ stateContainer });
-      act(() => {
-        fetch$.next({
-          options: { reset: false, fetchMore: false },
-          searchSessionId: '1234',
-        });
-      });
-      expect(hook.result.current.isChartLoading).toBe(true);
-    });
-  });
-
-  describe('refetching', () => {
-    it('should call refetch when savedSearchFetch$ is triggered', async () => {
-      const savedSearchFetch$ = new Subject<{
-        options: {
-          reset: boolean;
-          fetchMore: boolean;
-        };
-        searchSessionId: string;
-      }>();
-      const stateContainer = getStateContainer();
-      stateContainer.dataState.fetch$ = savedSearchFetch$;
-      const { hook } = await renderUseDiscoverHistogram({ stateContainer });
-      const api = createMockUnifiedHistogramApi();
-      act(() => {
-        hook.result.current.ref(api);
-      });
-      expect(api.refetch).toHaveBeenCalled();
-      act(() => {
-        savedSearchFetch$.next({
-          options: { reset: false, fetchMore: false },
-          searchSessionId: '1234',
-        });
-      });
-      expect(api.refetch).toHaveBeenCalledTimes(2);
-    });
-
-    it('should skip the next refetch when hideChart changes from true to false', async () => {
-      const savedSearchFetch$ = new Subject<{
-        options: {
-          reset: boolean;
-          fetchMore: boolean;
-        };
-        searchSessionId: string;
-      }>();
-      const stateContainer = getStateContainer();
-      stateContainer.dataState.fetch$ = savedSearchFetch$;
-      const { hook, initialProps } = await renderUseDiscoverHistogram({ stateContainer });
-      const api = createMockUnifiedHistogramApi();
-      act(() => {
-        hook.result.current.ref(api);
-      });
-      expect(api.refetch).toHaveBeenCalled();
-      act(() => {
-        hook.rerender({ ...initialProps, hideChart: true });
-      });
-      act(() => {
-        hook.rerender({ ...initialProps, hideChart: false });
-      });
-      act(() => {
-        savedSearchFetch$.next({
-          options: { reset: false, fetchMore: false },
-          searchSessionId: '1234',
-        });
-      });
-      expect(api.refetch).toHaveBeenCalledTimes(1);
-    });
-
-    it('should skip the next refetch when fetching more', async () => {
-      const savedSearchFetch$ = new Subject<{
-        options: {
-          reset: boolean;
-          fetchMore: boolean;
-        };
-        searchSessionId: string;
-      }>();
-      const stateContainer = getStateContainer();
-      stateContainer.dataState.fetch$ = savedSearchFetch$;
-      const { hook } = await renderUseDiscoverHistogram({ stateContainer });
-      const api = createMockUnifiedHistogramApi();
-      act(() => {
-        hook.result.current.ref(api);
-      });
-      expect(api.refetch).toHaveBeenCalledTimes(1);
-      act(() => {
-        savedSearchFetch$.next({
-          options: { reset: false, fetchMore: true },
-          searchSessionId: '1234',
-        });
-      });
-      expect(api.refetch).toHaveBeenCalledTimes(1);
-
-      act(() => {
-        savedSearchFetch$.next({
-          options: { reset: false, fetchMore: false },
-          searchSessionId: '1234',
-        });
-      });
-      expect(api.refetch).toHaveBeenCalledTimes(2);
-    });
-  });
-
-  describe('customization', () => {
-    test('should use custom values provided by customization fwk ', async () => {
-      mockUseCustomizations = true;
-      const stateContainer = getStateContainer();
-      const { hook } = await renderUseDiscoverHistogram({ stateContainer });
-
-      expect(hook.result.current.onFilter).toEqual(mockHistogramCustomization.onFilter);
-      expect(hook.result.current.onBrushEnd).toEqual(mockHistogramCustomization.onBrushEnd);
-      expect(hook.result.current.withDefaultActions).toEqual(
-        mockHistogramCustomization.withDefaultActions
-      );
-      expect(hook.result.current.disabledActions).toBeUndefined();
-    });
-  });
+  it('temp', () => {});
 });
+
+// import React, { ReactElement } from 'react';
+// import { AggregateQuery, Query } from '@kbn/es-query';
+// import { act, renderHook, WrapperComponent } from '@testing-library/react-hooks';
+// import { BehaviorSubject, Subject } from 'rxjs';
+// import { FetchStatus } from '../../../types';
+// import type { DiscoverStateContainer } from '../../state_management/discover_state';
+// import { dataPluginMock } from '@kbn/data-plugin/public/mocks';
+// import { useDiscoverHistogram, UseDiscoverHistogramProps } from './use_discover_histogram';
+// import { setTimeout } from 'timers/promises';
+// import { getDiscoverStateMock } from '../../../../__mocks__/discover_state.mock';
+// import { DiscoverMainProvider } from '../../state_management/discover_state_provider';
+// import { RequestAdapter } from '@kbn/inspector-plugin/public';
+// import {
+//   UnifiedHistogramFetchStatus,
+//   UnifiedHistogramState,
+// } from '@kbn/unified-histogram-plugin/public';
+// import { createMockUnifiedHistogramApi } from '@kbn/unified-histogram-plugin/public/mocks';
+// import { checkHitCount, sendErrorTo } from '../../hooks/use_saved_search_messages';
+// import type { InspectorAdapters } from '../../hooks/use_inspector';
+// import { UnifiedHistogramCustomization } from '../../../../customizations/customization_types/histogram_customization';
+// import { useDiscoverCustomization } from '../../../../customizations';
+// import { DiscoverCustomizationId } from '../../../../customizations/customization_service';
+
+// const mockData = dataPluginMock.createStartContract();
+// let mockQueryState = {
+//   query: {
+//     query: 'query',
+//     language: 'kuery',
+//   } as Query | AggregateQuery,
+//   filters: [],
+//   time: {
+//     from: 'now-15m',
+//     to: 'now',
+//   },
+// };
+
+// mockData.query.getState = () => mockQueryState;
+
+// jest.mock('../../../../hooks/use_discover_services', () => {
+//   const originalModule = jest.requireActual('../../../../hooks/use_discover_services');
+//   return {
+//     ...originalModule,
+//     useDiscoverServices: () => ({ data: mockData }),
+//   };
+// });
+
+// jest.mock('@kbn/unified-field-list/src/hooks/use_query_subscriber', () => {
+//   const originalModule = jest.requireActual(
+//     '@kbn/unified-field-list/src/hooks/use_query_subscriber'
+//   );
+//   return {
+//     ...originalModule,
+//     useQuerySubscriber: jest.fn(() => ({
+//       ...mockQueryState,
+//       fromDate: 'now-15m',
+//       toDate: 'now',
+//     })),
+//   };
+// });
+
+// jest.mock('../../hooks/use_saved_search_messages', () => {
+//   const originalModule = jest.requireActual('../../hooks/use_saved_search_messages');
+//   return {
+//     ...originalModule,
+//     checkHitCount: jest.fn(originalModule.checkHitCount),
+//     sendErrorTo: jest.fn(originalModule.sendErrorTo),
+//   };
+// });
+// jest.mock('../../../../customizations', () => ({
+//   ...jest.requireActual('../../../../customizations'),
+//   useDiscoverCustomization: jest.fn(),
+// }));
+
+// let mockUseCustomizations = false;
+
+// const mockHistogramCustomization: UnifiedHistogramCustomization = {
+//   id: 'unified_histogram',
+//   onFilter: jest.fn(),
+//   onBrushEnd: jest.fn(),
+//   withDefaultActions: true,
+// };
+
+// const mockCheckHitCount = checkHitCount as jest.MockedFunction<typeof checkHitCount>;
+
+// describe('useDiscoverHistogram', () => {
+//   const getStateContainer = () => {
+//     const stateContainer = getDiscoverStateMock({ isTimeBased: true });
+//     stateContainer.appState.update({
+//       interval: 'auto',
+//       hideChart: false,
+//       breakdownField: 'extension',
+//     });
+//     const appState = stateContainer.appState;
+//     const wrappedStateContainer = Object.create(appState);
+//     wrappedStateContainer.update = jest.fn((newState) => appState.update(newState));
+//     stateContainer.appState = wrappedStateContainer;
+//     return stateContainer;
+//   };
+
+//   const renderUseDiscoverHistogram = async ({
+//     stateContainer = getStateContainer(),
+//     inspectorAdapters = { requests: new RequestAdapter() },
+//     hideChart = false,
+//   }: {
+//     stateContainer?: DiscoverStateContainer;
+//     inspectorAdapters?: InspectorAdapters;
+//     hideChart?: boolean;
+//   } = {}) => {
+//     const initialProps = {
+//       stateContainer,
+//       inspectorAdapters,
+//       hideChart,
+//     };
+
+//     const Wrapper: WrapperComponent<React.PropsWithChildren<UseDiscoverHistogramProps>> = ({
+//       children,
+//     }) => (
+//       <DiscoverMainProvider value={stateContainer}>{children as ReactElement}</DiscoverMainProvider>
+//     );
+
+//     const hook = renderHook(
+//       (props: UseDiscoverHistogramProps) => {
+//         return useDiscoverHistogram(props);
+//       },
+//       {
+//         wrapper: Wrapper,
+//         initialProps,
+//       }
+//     );
+
+//     await act(() => setTimeout(0));
+
+//     return { hook, initialProps };
+//   };
+
+//   beforeEach(() => {
+//     mockUseCustomizations = false;
+//     jest.clearAllMocks();
+
+//     (useDiscoverCustomization as jest.Mock).mockImplementation((id: DiscoverCustomizationId) => {
+//       if (!mockUseCustomizations) {
+//         return undefined;
+//       }
+//       switch (id) {
+//         case 'unified_histogram':
+//           return mockHistogramCustomization;
+//         default:
+//           throw new Error(`Unknown customization id: ${id}`);
+//       }
+//     });
+//   });
+
+//   describe('initialization', () => {
+//     it('should return the expected parameters from getCreationOptions', async () => {
+//       const { hook } = await renderUseDiscoverHistogram();
+//       const params = hook.result.current.getCreationOptions();
+//       expect(params?.localStorageKeyPrefix).toBe('discover');
+//       expect(params?.disableAutoFetching).toBe(true);
+//       expect(Object.keys(params?.initialState ?? {})).toEqual([
+//         'chartHidden',
+//         'timeInterval',
+//         'breakdownField',
+//         'totalHitsStatus',
+//         'totalHitsResult',
+//       ]);
+//     });
+
+//     it('should return the isChartLoading params for ES|QL mode', async () => {
+//       const stateContainer = getStateContainer();
+//       stateContainer.appState.update({ query: { esql: 'from *' } });
+//       const { hook } = await renderUseDiscoverHistogram();
+//       const isChartLoading = hook.result.current.isChartLoading;
+//       expect(isChartLoading).toBe(false);
+//     });
+//   });
+
+//   describe('state', () => {
+//     beforeEach(() => {
+//       mockCheckHitCount.mockClear();
+//     });
+
+//     it('should subscribe to state changes', async () => {
+//       const { hook } = await renderUseDiscoverHistogram();
+//       const api = createMockUnifiedHistogramApi();
+//       jest.spyOn(api.state$, 'subscribe');
+//       act(() => {
+//         hook.result.current.ref(api);
+//       });
+//       expect(api.state$.subscribe).toHaveBeenCalledTimes(2);
+//     });
+
+//     it('should sync Unified Histogram state with the state container', async () => {
+//       const stateContainer = getStateContainer();
+//       const inspectorAdapters = { requests: new RequestAdapter(), lensRequests: undefined };
+//       const { hook } = await renderUseDiscoverHistogram({ stateContainer, inspectorAdapters });
+//       const lensRequestAdapter = new RequestAdapter();
+//       const state = {
+//         timeInterval: '1m',
+//         chartHidden: true,
+//         breakdownField: 'test',
+//         totalHitsStatus: UnifiedHistogramFetchStatus.loading,
+//         totalHitsResult: undefined,
+//       } as unknown as UnifiedHistogramState;
+//       const api = createMockUnifiedHistogramApi();
+//       api.state$ = new BehaviorSubject({ ...state, lensRequestAdapter });
+//       act(() => {
+//         hook.result.current.ref(api);
+//       });
+//       expect(inspectorAdapters.lensRequests).toBe(lensRequestAdapter);
+//       expect(stateContainer.appState.update).toHaveBeenCalledWith({
+//         interval: state.timeInterval,
+//         hideChart: state.chartHidden,
+//         breakdownField: state.breakdownField,
+//       });
+//     });
+
+//     it('should not sync Unified Histogram state with the state container if there are no changes', async () => {
+//       const stateContainer = getStateContainer();
+//       const { hook } = await renderUseDiscoverHistogram({ stateContainer });
+//       const containerState = stateContainer.appState.getState();
+//       const state = {
+//         timeInterval: containerState.interval,
+//         chartHidden: containerState.hideChart,
+//         breakdownField: containerState.breakdownField,
+//         totalHitsStatus: UnifiedHistogramFetchStatus.loading,
+//         totalHitsResult: undefined,
+//       } as unknown as UnifiedHistogramState;
+//       const api = createMockUnifiedHistogramApi();
+//       api.state$ = new BehaviorSubject(state);
+//       act(() => {
+//         hook.result.current.ref(api);
+//       });
+//       expect(stateContainer.appState.update).not.toHaveBeenCalled();
+//     });
+
+//     it('should sync the state container state with Unified Histogram', async () => {
+//       const stateContainer = getStateContainer();
+//       const { hook } = await renderUseDiscoverHistogram({ stateContainer });
+//       const api = createMockUnifiedHistogramApi();
+//       let params: Partial<UnifiedHistogramState> = {};
+//       api.setTotalHits = jest.fn((p) => {
+//         params = { ...params, ...p };
+//       });
+//       api.setChartHidden = jest.fn((chartHidden) => {
+//         params = { ...params, chartHidden };
+//       });
+//       api.setTimeInterval = jest.fn((timeInterval) => {
+//         params = { ...params, timeInterval };
+//       });
+//       api.setBreakdownField = jest.fn((breakdownField) => {
+//         params = { ...params, breakdownField };
+//       });
+//       act(() => {
+//         hook.result.current.ref(api);
+//       });
+//       stateContainer.appState.update({ hideChart: true, interval: '1m', breakdownField: 'test' });
+//       expect(api.setTotalHits).not.toHaveBeenCalled();
+//       expect(api.setChartHidden).toHaveBeenCalled();
+//       expect(api.setTimeInterval).toHaveBeenCalled();
+//       expect(api.setBreakdownField).toHaveBeenCalled();
+//       expect(Object.keys(params ?? {})).toEqual(['breakdownField', 'timeInterval', 'chartHidden']);
+//     });
+
+//     it('should exclude totalHitsStatus and totalHitsResult from Unified Histogram state updates', async () => {
+//       const stateContainer = getStateContainer();
+//       const { hook } = await renderUseDiscoverHistogram({ stateContainer });
+//       const containerState = stateContainer.appState.getState();
+//       const state = {
+//         timeInterval: containerState.interval,
+//         chartHidden: containerState.hideChart,
+//         breakdownField: containerState.breakdownField,
+//         totalHitsStatus: UnifiedHistogramFetchStatus.loading,
+//         totalHitsResult: undefined,
+//       } as unknown as UnifiedHistogramState;
+//       const api = createMockUnifiedHistogramApi();
+//       let params: Partial<UnifiedHistogramState> = {};
+//       api.setChartHidden = jest.fn((chartHidden) => {
+//         params = { ...params, chartHidden };
+//       });
+//       const subject$ = new BehaviorSubject(state);
+//       api.state$ = subject$;
+//       act(() => {
+//         hook.result.current.ref(api);
+//       });
+//       stateContainer.appState.update({ hideChart: true });
+//       expect(Object.keys(params ?? {})).toEqual(['chartHidden']);
+//       params = {};
+//       stateContainer.appState.update({ hideChart: false });
+//       act(() => {
+//         subject$.next({
+//           ...state,
+//           totalHitsStatus: UnifiedHistogramFetchStatus.complete,
+//           totalHitsResult: 100,
+//         });
+//       });
+//       expect(Object.keys(params ?? {})).toEqual(['chartHidden']);
+//     });
+
+//     it('should update total hits when the total hits state changes', async () => {
+//       const stateContainer = getStateContainer();
+//       const { hook } = await renderUseDiscoverHistogram({ stateContainer });
+//       const containerState = stateContainer.appState.getState();
+//       const state = {
+//         timeInterval: containerState.interval,
+//         chartHidden: containerState.hideChart,
+//         breakdownField: containerState.breakdownField,
+//         totalHitsStatus: UnifiedHistogramFetchStatus.loading,
+//         totalHitsResult: undefined,
+//       } as unknown as UnifiedHistogramState;
+//       const api = createMockUnifiedHistogramApi();
+//       api.state$ = new BehaviorSubject({
+//         ...state,
+//         totalHitsStatus: UnifiedHistogramFetchStatus.complete,
+//         totalHitsResult: 100,
+//       });
+//       expect(stateContainer.dataState.data$.totalHits$.value).not.toEqual({
+//         fetchStatus: FetchStatus.COMPLETE,
+//         result: 100,
+//       });
+//       act(() => {
+//         hook.result.current.ref(api);
+//       });
+//       expect(stateContainer.dataState.data$.totalHits$.value).toEqual({
+//         fetchStatus: FetchStatus.COMPLETE,
+//         result: 100,
+//       });
+//       expect(mockCheckHitCount).toHaveBeenCalledWith(stateContainer.dataState.data$.main$, 100);
+//     });
+
+//     it('should not update total hits when the total hits state changes to an error', async () => {
+//       mockQueryState = {
+//         query: {
+//           query: 'query',
+//           language: 'kuery',
+//         } as Query | AggregateQuery,
+//         filters: [],
+//         time: {
+//           from: 'now-15m',
+//           to: 'now',
+//         },
+//       };
+
+//       mockData.query.getState = () => mockQueryState;
+//       const stateContainer = getStateContainer();
+//       const { hook } = await renderUseDiscoverHistogram({ stateContainer });
+//       const containerState = stateContainer.appState.getState();
+//       const error = new Error('test');
+//       const state = {
+//         timeInterval: containerState.interval,
+//         chartHidden: containerState.hideChart,
+//         breakdownField: containerState.breakdownField,
+//         totalHitsStatus: UnifiedHistogramFetchStatus.loading,
+//         totalHitsResult: undefined,
+//       } as unknown as UnifiedHistogramState;
+//       const api = createMockUnifiedHistogramApi();
+//       api.state$ = new BehaviorSubject({
+//         ...state,
+//         totalHitsStatus: UnifiedHistogramFetchStatus.error,
+//         totalHitsResult: error,
+//       });
+//       expect(stateContainer.dataState.data$.totalHits$.value).not.toEqual({
+//         fetchStatus: FetchStatus.ERROR,
+//         error,
+//       });
+//       act(() => {
+//         hook.result.current.ref(api);
+//       });
+//       expect(sendErrorTo).toHaveBeenCalledWith(stateContainer.dataState.data$.totalHits$);
+//       expect(stateContainer.dataState.data$.totalHits$.value).toEqual({
+//         fetchStatus: FetchStatus.ERROR,
+//         error,
+//       });
+//       expect(mockCheckHitCount).not.toHaveBeenCalled();
+//     });
+
+//     it('should set isChartLoading to true for fetch start', async () => {
+//       const fetch$ = new Subject<{
+//         options: {
+//           reset: boolean;
+//           fetchMore: boolean;
+//         };
+//         searchSessionId: string;
+//       }>();
+//       const stateContainer = getStateContainer();
+//       stateContainer.appState.update({ query: { esql: 'from *' } });
+//       stateContainer.dataState.fetch$ = fetch$;
+//       const { hook } = await renderUseDiscoverHistogram({ stateContainer });
+//       act(() => {
+//         fetch$.next({
+//           options: { reset: false, fetchMore: false },
+//           searchSessionId: '1234',
+//         });
+//       });
+//       expect(hook.result.current.isChartLoading).toBe(true);
+//     });
+//   });
+
+//   describe('refetching', () => {
+//     it('should call refetch when savedSearchFetch$ is triggered', async () => {
+//       const savedSearchFetch$ = new Subject<{
+//         options: {
+//           reset: boolean;
+//           fetchMore: boolean;
+//         };
+//         searchSessionId: string;
+//       }>();
+//       const stateContainer = getStateContainer();
+//       stateContainer.dataState.fetch$ = savedSearchFetch$;
+//       const { hook } = await renderUseDiscoverHistogram({ stateContainer });
+//       const api = createMockUnifiedHistogramApi();
+//       act(() => {
+//         hook.result.current.ref(api);
+//       });
+//       expect(api.refetch).toHaveBeenCalled();
+//       act(() => {
+//         savedSearchFetch$.next({
+//           options: { reset: false, fetchMore: false },
+//           searchSessionId: '1234',
+//         });
+//       });
+//       expect(api.refetch).toHaveBeenCalledTimes(2);
+//     });
+
+//     it('should skip the next refetch when hideChart changes from true to false', async () => {
+//       const savedSearchFetch$ = new Subject<{
+//         options: {
+//           reset: boolean;
+//           fetchMore: boolean;
+//         };
+//         searchSessionId: string;
+//       }>();
+//       const stateContainer = getStateContainer();
+//       stateContainer.dataState.fetch$ = savedSearchFetch$;
+//       const { hook, initialProps } = await renderUseDiscoverHistogram({ stateContainer });
+//       const api = createMockUnifiedHistogramApi();
+//       act(() => {
+//         hook.result.current.ref(api);
+//       });
+//       expect(api.refetch).toHaveBeenCalled();
+//       act(() => {
+//         hook.rerender({ ...initialProps, hideChart: true });
+//       });
+//       act(() => {
+//         hook.rerender({ ...initialProps, hideChart: false });
+//       });
+//       act(() => {
+//         savedSearchFetch$.next({
+//           options: { reset: false, fetchMore: false },
+//           searchSessionId: '1234',
+//         });
+//       });
+//       expect(api.refetch).toHaveBeenCalledTimes(1);
+//     });
+
+//     it('should skip the next refetch when fetching more', async () => {
+//       const savedSearchFetch$ = new Subject<{
+//         options: {
+//           reset: boolean;
+//           fetchMore: boolean;
+//         };
+//         searchSessionId: string;
+//       }>();
+//       const stateContainer = getStateContainer();
+//       stateContainer.dataState.fetch$ = savedSearchFetch$;
+//       const { hook } = await renderUseDiscoverHistogram({ stateContainer });
+//       const api = createMockUnifiedHistogramApi();
+//       act(() => {
+//         hook.result.current.ref(api);
+//       });
+//       expect(api.refetch).toHaveBeenCalledTimes(1);
+//       act(() => {
+//         savedSearchFetch$.next({
+//           options: { reset: false, fetchMore: true },
+//           searchSessionId: '1234',
+//         });
+//       });
+//       expect(api.refetch).toHaveBeenCalledTimes(1);
+
+//       act(() => {
+//         savedSearchFetch$.next({
+//           options: { reset: false, fetchMore: false },
+//           searchSessionId: '1234',
+//         });
+//       });
+//       expect(api.refetch).toHaveBeenCalledTimes(2);
+//     });
+//   });
+
+//   describe('customization', () => {
+//     test('should use custom values provided by customization fwk ', async () => {
+//       mockUseCustomizations = true;
+//       const stateContainer = getStateContainer();
+//       const { hook } = await renderUseDiscoverHistogram({ stateContainer });
+
+//       expect(hook.result.current.onFilter).toEqual(mockHistogramCustomization.onFilter);
+//       expect(hook.result.current.onBrushEnd).toEqual(mockHistogramCustomization.onBrushEnd);
+//       expect(hook.result.current.withDefaultActions).toEqual(
+//         mockHistogramCustomization.withDefaultActions
+//       );
+//       expect(hook.result.current.disabledActions).toBeUndefined();
+//     });
+//   });
+// });

--- a/src/plugins/discover/public/application/main/components/layout/use_discover_histogram.test.tsx
+++ b/src/plugins/discover/public/application/main/components/layout/use_discover_histogram.test.tsx
@@ -7,510 +7,434 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-describe('useDiscoverHistogram', () => {
-  it('temp', () => {});
+import React, { ReactElement } from 'react';
+import { AggregateQuery, Query } from '@kbn/es-query';
+import { act, renderHook, WrapperComponent } from '@testing-library/react-hooks';
+import { BehaviorSubject, Subject } from 'rxjs';
+import { FetchStatus } from '../../../types';
+import type { DiscoverStateContainer } from '../../state_management/discover_state';
+import { dataPluginMock } from '@kbn/data-plugin/public/mocks';
+import { useDiscoverHistogram, UseDiscoverHistogramProps } from './use_discover_histogram';
+import { setTimeout } from 'timers/promises';
+import { getDiscoverStateMock } from '../../../../__mocks__/discover_state.mock';
+import { DiscoverMainProvider } from '../../state_management/discover_state_provider';
+import { RequestAdapter } from '@kbn/inspector-plugin/public';
+import {
+  UnifiedHistogramFetchStatus,
+  UnifiedHistogramState,
+} from '@kbn/unified-histogram-plugin/public';
+import { createMockUnifiedHistogramApi } from '@kbn/unified-histogram-plugin/public/mocks';
+import { checkHitCount, sendErrorTo } from '../../hooks/use_saved_search_messages';
+import type { InspectorAdapters } from '../../hooks/use_inspector';
+import { UnifiedHistogramCustomization } from '../../../../customizations/customization_types/histogram_customization';
+import { useDiscoverCustomization } from '../../../../customizations';
+import { DiscoverCustomizationId } from '../../../../customizations/customization_service';
+
+const mockData = dataPluginMock.createStartContract();
+let mockQueryState = {
+  query: {
+    query: 'query',
+    language: 'kuery',
+  } as Query | AggregateQuery,
+  filters: [],
+  time: {
+    from: 'now-15m',
+    to: 'now',
+  },
+};
+
+mockData.query.getState = () => mockQueryState;
+
+jest.mock('../../../../hooks/use_discover_services', () => {
+  const originalModule = jest.requireActual('../../../../hooks/use_discover_services');
+  return {
+    ...originalModule,
+    useDiscoverServices: () => ({ data: mockData }),
+  };
 });
 
-// import React, { ReactElement } from 'react';
-// import { AggregateQuery, Query } from '@kbn/es-query';
-// import { act, renderHook, WrapperComponent } from '@testing-library/react-hooks';
-// import { BehaviorSubject, Subject } from 'rxjs';
-// import { FetchStatus } from '../../../types';
-// import type { DiscoverStateContainer } from '../../state_management/discover_state';
-// import { dataPluginMock } from '@kbn/data-plugin/public/mocks';
-// import { useDiscoverHistogram, UseDiscoverHistogramProps } from './use_discover_histogram';
-// import { setTimeout } from 'timers/promises';
-// import { getDiscoverStateMock } from '../../../../__mocks__/discover_state.mock';
-// import { DiscoverMainProvider } from '../../state_management/discover_state_provider';
-// import { RequestAdapter } from '@kbn/inspector-plugin/public';
-// import {
-//   UnifiedHistogramFetchStatus,
-//   UnifiedHistogramState,
-// } from '@kbn/unified-histogram-plugin/public';
-// import { createMockUnifiedHistogramApi } from '@kbn/unified-histogram-plugin/public/mocks';
-// import { checkHitCount, sendErrorTo } from '../../hooks/use_saved_search_messages';
-// import type { InspectorAdapters } from '../../hooks/use_inspector';
-// import { UnifiedHistogramCustomization } from '../../../../customizations/customization_types/histogram_customization';
-// import { useDiscoverCustomization } from '../../../../customizations';
-// import { DiscoverCustomizationId } from '../../../../customizations/customization_service';
+jest.mock('@kbn/unified-field-list/src/hooks/use_query_subscriber', () => {
+  const originalModule = jest.requireActual(
+    '@kbn/unified-field-list/src/hooks/use_query_subscriber'
+  );
+  return {
+    ...originalModule,
+    useQuerySubscriber: jest.fn(() => ({
+      ...mockQueryState,
+      fromDate: 'now-15m',
+      toDate: 'now',
+    })),
+  };
+});
 
-// const mockData = dataPluginMock.createStartContract();
-// let mockQueryState = {
-//   query: {
-//     query: 'query',
-//     language: 'kuery',
-//   } as Query | AggregateQuery,
-//   filters: [],
-//   time: {
-//     from: 'now-15m',
-//     to: 'now',
-//   },
-// };
+jest.mock('../../hooks/use_saved_search_messages', () => {
+  const originalModule = jest.requireActual('../../hooks/use_saved_search_messages');
+  return {
+    ...originalModule,
+    checkHitCount: jest.fn(originalModule.checkHitCount),
+    sendErrorTo: jest.fn(originalModule.sendErrorTo),
+  };
+});
+jest.mock('../../../../customizations', () => ({
+  ...jest.requireActual('../../../../customizations'),
+  useDiscoverCustomization: jest.fn(),
+}));
 
-// mockData.query.getState = () => mockQueryState;
+let mockUseCustomizations = false;
 
-// jest.mock('../../../../hooks/use_discover_services', () => {
-//   const originalModule = jest.requireActual('../../../../hooks/use_discover_services');
-//   return {
-//     ...originalModule,
-//     useDiscoverServices: () => ({ data: mockData }),
-//   };
-// });
+const mockHistogramCustomization: UnifiedHistogramCustomization = {
+  id: 'unified_histogram',
+  onFilter: jest.fn(),
+  onBrushEnd: jest.fn(),
+  withDefaultActions: true,
+};
 
-// jest.mock('@kbn/unified-field-list/src/hooks/use_query_subscriber', () => {
-//   const originalModule = jest.requireActual(
-//     '@kbn/unified-field-list/src/hooks/use_query_subscriber'
-//   );
-//   return {
-//     ...originalModule,
-//     useQuerySubscriber: jest.fn(() => ({
-//       ...mockQueryState,
-//       fromDate: 'now-15m',
-//       toDate: 'now',
-//     })),
-//   };
-// });
+const mockCheckHitCount = checkHitCount as jest.MockedFunction<typeof checkHitCount>;
 
-// jest.mock('../../hooks/use_saved_search_messages', () => {
-//   const originalModule = jest.requireActual('../../hooks/use_saved_search_messages');
-//   return {
-//     ...originalModule,
-//     checkHitCount: jest.fn(originalModule.checkHitCount),
-//     sendErrorTo: jest.fn(originalModule.sendErrorTo),
-//   };
-// });
-// jest.mock('../../../../customizations', () => ({
-//   ...jest.requireActual('../../../../customizations'),
-//   useDiscoverCustomization: jest.fn(),
-// }));
+describe('useDiscoverHistogram', () => {
+  const getStateContainer = () => {
+    const stateContainer = getDiscoverStateMock({ isTimeBased: true });
+    stateContainer.appState.update({
+      interval: 'auto',
+      hideChart: false,
+    });
+    const appState = stateContainer.appState;
+    const wrappedStateContainer = Object.create(appState);
+    wrappedStateContainer.update = jest.fn((newState) => appState.update(newState));
+    stateContainer.appState = wrappedStateContainer;
+    return stateContainer;
+  };
 
-// let mockUseCustomizations = false;
+  const renderUseDiscoverHistogram = async ({
+    stateContainer = getStateContainer(),
+    inspectorAdapters = { requests: new RequestAdapter() },
+    hideChart = false,
+  }: {
+    stateContainer?: DiscoverStateContainer;
+    inspectorAdapters?: InspectorAdapters;
+    hideChart?: boolean;
+  } = {}) => {
+    const initialProps = {
+      stateContainer,
+      inspectorAdapters,
+      hideChart,
+    };
 
-// const mockHistogramCustomization: UnifiedHistogramCustomization = {
-//   id: 'unified_histogram',
-//   onFilter: jest.fn(),
-//   onBrushEnd: jest.fn(),
-//   withDefaultActions: true,
-// };
+    const Wrapper: WrapperComponent<React.PropsWithChildren<UseDiscoverHistogramProps>> = ({
+      children,
+    }) => (
+      <DiscoverMainProvider value={stateContainer}>{children as ReactElement}</DiscoverMainProvider>
+    );
 
-// const mockCheckHitCount = checkHitCount as jest.MockedFunction<typeof checkHitCount>;
+    const hook = renderHook(
+      (props: UseDiscoverHistogramProps) => {
+        return useDiscoverHistogram(props);
+      },
+      {
+        wrapper: Wrapper,
+        initialProps,
+      }
+    );
 
-// describe('useDiscoverHistogram', () => {
-//   const getStateContainer = () => {
-//     const stateContainer = getDiscoverStateMock({ isTimeBased: true });
-//     stateContainer.appState.update({
-//       interval: 'auto',
-//       hideChart: false,
-//       breakdownField: 'extension',
-//     });
-//     const appState = stateContainer.appState;
-//     const wrappedStateContainer = Object.create(appState);
-//     wrappedStateContainer.update = jest.fn((newState) => appState.update(newState));
-//     stateContainer.appState = wrappedStateContainer;
-//     return stateContainer;
-//   };
+    await act(() => setTimeout(0));
 
-//   const renderUseDiscoverHistogram = async ({
-//     stateContainer = getStateContainer(),
-//     inspectorAdapters = { requests: new RequestAdapter() },
-//     hideChart = false,
-//   }: {
-//     stateContainer?: DiscoverStateContainer;
-//     inspectorAdapters?: InspectorAdapters;
-//     hideChart?: boolean;
-//   } = {}) => {
-//     const initialProps = {
-//       stateContainer,
-//       inspectorAdapters,
-//       hideChart,
-//     };
+    return { hook, initialProps };
+  };
 
-//     const Wrapper: WrapperComponent<React.PropsWithChildren<UseDiscoverHistogramProps>> = ({
-//       children,
-//     }) => (
-//       <DiscoverMainProvider value={stateContainer}>{children as ReactElement}</DiscoverMainProvider>
-//     );
+  beforeEach(() => {
+    mockUseCustomizations = false;
+    jest.clearAllMocks();
 
-//     const hook = renderHook(
-//       (props: UseDiscoverHistogramProps) => {
-//         return useDiscoverHistogram(props);
-//       },
-//       {
-//         wrapper: Wrapper,
-//         initialProps,
-//       }
-//     );
+    (useDiscoverCustomization as jest.Mock).mockImplementation((id: DiscoverCustomizationId) => {
+      if (!mockUseCustomizations) {
+        return undefined;
+      }
+      switch (id) {
+        case 'unified_histogram':
+          return mockHistogramCustomization;
+        default:
+          throw new Error(`Unknown customization id: ${id}`);
+      }
+    });
+  });
 
-//     await act(() => setTimeout(0));
+  describe('initialization', () => {
+    it('should return the expected parameters from getCreationOptions', async () => {
+      const { hook } = await renderUseDiscoverHistogram();
+      const params = hook.result.current.getCreationOptions();
+      expect(params?.localStorageKeyPrefix).toBe('discover');
+      expect(params?.disableAutoFetching).toBe(true);
+      expect(Object.keys(params?.initialState ?? {})).toEqual([
+        'chartHidden',
+        'timeInterval',
+        'totalHitsStatus',
+        'totalHitsResult',
+      ]);
+    });
 
-//     return { hook, initialProps };
-//   };
+    it('should return the isChartLoading params for ES|QL mode', async () => {
+      const stateContainer = getStateContainer();
+      stateContainer.appState.update({ query: { esql: 'from *' } });
+      const { hook } = await renderUseDiscoverHistogram();
+      const isChartLoading = hook.result.current.isChartLoading;
+      expect(isChartLoading).toBe(false);
+    });
+  });
 
-//   beforeEach(() => {
-//     mockUseCustomizations = false;
-//     jest.clearAllMocks();
+  describe('state', () => {
+    beforeEach(() => {
+      mockCheckHitCount.mockClear();
+    });
 
-//     (useDiscoverCustomization as jest.Mock).mockImplementation((id: DiscoverCustomizationId) => {
-//       if (!mockUseCustomizations) {
-//         return undefined;
-//       }
-//       switch (id) {
-//         case 'unified_histogram':
-//           return mockHistogramCustomization;
-//         default:
-//           throw new Error(`Unknown customization id: ${id}`);
-//       }
-//     });
-//   });
+    it('should subscribe to state changes', async () => {
+      const { hook } = await renderUseDiscoverHistogram();
+      const api = createMockUnifiedHistogramApi();
+      jest.spyOn(api.state$, 'subscribe');
+      act(() => {
+        hook.result.current.ref(api);
+      });
+      expect(api.state$.subscribe).toHaveBeenCalledTimes(2);
+    });
 
-//   describe('initialization', () => {
-//     it('should return the expected parameters from getCreationOptions', async () => {
-//       const { hook } = await renderUseDiscoverHistogram();
-//       const params = hook.result.current.getCreationOptions();
-//       expect(params?.localStorageKeyPrefix).toBe('discover');
-//       expect(params?.disableAutoFetching).toBe(true);
-//       expect(Object.keys(params?.initialState ?? {})).toEqual([
-//         'chartHidden',
-//         'timeInterval',
-//         'breakdownField',
-//         'totalHitsStatus',
-//         'totalHitsResult',
-//       ]);
-//     });
+    it('should sync Unified Histogram state with the state container', async () => {
+      const stateContainer = getStateContainer();
+      const inspectorAdapters = { requests: new RequestAdapter(), lensRequests: undefined };
+      const { hook } = await renderUseDiscoverHistogram({ stateContainer, inspectorAdapters });
+      const lensRequestAdapter = new RequestAdapter();
+      const state = {
+        timeInterval: '1m',
+        chartHidden: true,
+        totalHitsStatus: UnifiedHistogramFetchStatus.loading,
+        totalHitsResult: undefined,
+      } as unknown as UnifiedHistogramState;
+      const api = createMockUnifiedHistogramApi();
+      api.state$ = new BehaviorSubject({ ...state, lensRequestAdapter });
+      act(() => {
+        hook.result.current.ref(api);
+      });
+      expect(inspectorAdapters.lensRequests).toBe(lensRequestAdapter);
+      expect(stateContainer.appState.update).toHaveBeenCalledWith({
+        interval: state.timeInterval,
+        hideChart: state.chartHidden,
+      });
+    });
 
-//     it('should return the isChartLoading params for ES|QL mode', async () => {
-//       const stateContainer = getStateContainer();
-//       stateContainer.appState.update({ query: { esql: 'from *' } });
-//       const { hook } = await renderUseDiscoverHistogram();
-//       const isChartLoading = hook.result.current.isChartLoading;
-//       expect(isChartLoading).toBe(false);
-//     });
-//   });
+    it('should not sync Unified Histogram state with the state container if there are no changes', async () => {
+      const stateContainer = getStateContainer();
+      const { hook } = await renderUseDiscoverHistogram({ stateContainer });
+      const containerState = stateContainer.appState.getState();
+      const state = {
+        timeInterval: containerState.interval,
+        chartHidden: containerState.hideChart,
+        totalHitsStatus: UnifiedHistogramFetchStatus.loading,
+        totalHitsResult: undefined,
+      } as unknown as UnifiedHistogramState;
+      const api = createMockUnifiedHistogramApi();
+      api.state$ = new BehaviorSubject(state);
+      act(() => {
+        hook.result.current.ref(api);
+      });
+      expect(stateContainer.appState.update).not.toHaveBeenCalled();
+    });
 
-//   describe('state', () => {
-//     beforeEach(() => {
-//       mockCheckHitCount.mockClear();
-//     });
+    it('should sync the state container state with Unified Histogram', async () => {
+      const stateContainer = getStateContainer();
+      const { hook } = await renderUseDiscoverHistogram({ stateContainer });
+      const api = createMockUnifiedHistogramApi();
+      let params: Partial<UnifiedHistogramState> = {};
+      api.setTotalHits = jest.fn((p) => {
+        params = { ...params, ...p };
+      });
+      api.setChartHidden = jest.fn((chartHidden) => {
+        params = { ...params, chartHidden };
+      });
+      api.setTimeInterval = jest.fn((timeInterval) => {
+        params = { ...params, timeInterval };
+      });
+      act(() => {
+        hook.result.current.ref(api);
+      });
+      stateContainer.appState.update({ hideChart: true, interval: '1m' });
+      expect(api.setTotalHits).not.toHaveBeenCalled();
+      expect(api.setChartHidden).toHaveBeenCalled();
+      expect(api.setTimeInterval).toHaveBeenCalled();
+      expect(Object.keys(params ?? {})).toEqual(['timeInterval', 'chartHidden']);
+    });
 
-//     it('should subscribe to state changes', async () => {
-//       const { hook } = await renderUseDiscoverHistogram();
-//       const api = createMockUnifiedHistogramApi();
-//       jest.spyOn(api.state$, 'subscribe');
-//       act(() => {
-//         hook.result.current.ref(api);
-//       });
-//       expect(api.state$.subscribe).toHaveBeenCalledTimes(2);
-//     });
+    it('should exclude totalHitsStatus and totalHitsResult from Unified Histogram state updates', async () => {
+      const stateContainer = getStateContainer();
+      const { hook } = await renderUseDiscoverHistogram({ stateContainer });
+      const containerState = stateContainer.appState.getState();
+      const state = {
+        timeInterval: containerState.interval,
+        chartHidden: containerState.hideChart,
+        totalHitsStatus: UnifiedHistogramFetchStatus.loading,
+        totalHitsResult: undefined,
+      } as unknown as UnifiedHistogramState;
+      const api = createMockUnifiedHistogramApi();
+      let params: Partial<UnifiedHistogramState> = {};
+      api.setChartHidden = jest.fn((chartHidden) => {
+        params = { ...params, chartHidden };
+      });
+      const subject$ = new BehaviorSubject(state);
+      api.state$ = subject$;
+      act(() => {
+        hook.result.current.ref(api);
+      });
+      stateContainer.appState.update({ hideChart: true });
+      expect(Object.keys(params ?? {})).toEqual(['chartHidden']);
+      params = {};
+      stateContainer.appState.update({ hideChart: false });
+      act(() => {
+        subject$.next({
+          ...state,
+          totalHitsStatus: UnifiedHistogramFetchStatus.complete,
+          totalHitsResult: 100,
+        });
+      });
+      expect(Object.keys(params ?? {})).toEqual(['chartHidden']);
+    });
 
-//     it('should sync Unified Histogram state with the state container', async () => {
-//       const stateContainer = getStateContainer();
-//       const inspectorAdapters = { requests: new RequestAdapter(), lensRequests: undefined };
-//       const { hook } = await renderUseDiscoverHistogram({ stateContainer, inspectorAdapters });
-//       const lensRequestAdapter = new RequestAdapter();
-//       const state = {
-//         timeInterval: '1m',
-//         chartHidden: true,
-//         breakdownField: 'test',
-//         totalHitsStatus: UnifiedHistogramFetchStatus.loading,
-//         totalHitsResult: undefined,
-//       } as unknown as UnifiedHistogramState;
-//       const api = createMockUnifiedHistogramApi();
-//       api.state$ = new BehaviorSubject({ ...state, lensRequestAdapter });
-//       act(() => {
-//         hook.result.current.ref(api);
-//       });
-//       expect(inspectorAdapters.lensRequests).toBe(lensRequestAdapter);
-//       expect(stateContainer.appState.update).toHaveBeenCalledWith({
-//         interval: state.timeInterval,
-//         hideChart: state.chartHidden,
-//         breakdownField: state.breakdownField,
-//       });
-//     });
+    it('should update total hits when the total hits state changes', async () => {
+      const stateContainer = getStateContainer();
+      const { hook } = await renderUseDiscoverHistogram({ stateContainer });
+      const containerState = stateContainer.appState.getState();
+      const state = {
+        timeInterval: containerState.interval,
+        chartHidden: containerState.hideChart,
+        totalHitsStatus: UnifiedHistogramFetchStatus.loading,
+        totalHitsResult: undefined,
+      } as unknown as UnifiedHistogramState;
+      const api = createMockUnifiedHistogramApi();
+      api.state$ = new BehaviorSubject({
+        ...state,
+        totalHitsStatus: UnifiedHistogramFetchStatus.complete,
+        totalHitsResult: 100,
+      });
+      expect(stateContainer.dataState.data$.totalHits$.value).not.toEqual({
+        fetchStatus: FetchStatus.COMPLETE,
+        result: 100,
+      });
+      act(() => {
+        hook.result.current.ref(api);
+      });
+      expect(stateContainer.dataState.data$.totalHits$.value).toEqual({
+        fetchStatus: FetchStatus.COMPLETE,
+        result: 100,
+      });
+      expect(mockCheckHitCount).toHaveBeenCalledWith(stateContainer.dataState.data$.main$, 100);
+    });
 
-//     it('should not sync Unified Histogram state with the state container if there are no changes', async () => {
-//       const stateContainer = getStateContainer();
-//       const { hook } = await renderUseDiscoverHistogram({ stateContainer });
-//       const containerState = stateContainer.appState.getState();
-//       const state = {
-//         timeInterval: containerState.interval,
-//         chartHidden: containerState.hideChart,
-//         breakdownField: containerState.breakdownField,
-//         totalHitsStatus: UnifiedHistogramFetchStatus.loading,
-//         totalHitsResult: undefined,
-//       } as unknown as UnifiedHistogramState;
-//       const api = createMockUnifiedHistogramApi();
-//       api.state$ = new BehaviorSubject(state);
-//       act(() => {
-//         hook.result.current.ref(api);
-//       });
-//       expect(stateContainer.appState.update).not.toHaveBeenCalled();
-//     });
+    it('should not update total hits when the total hits state changes to an error', async () => {
+      mockQueryState = {
+        query: {
+          query: 'query',
+          language: 'kuery',
+        } as Query | AggregateQuery,
+        filters: [],
+        time: {
+          from: 'now-15m',
+          to: 'now',
+        },
+      };
 
-//     it('should sync the state container state with Unified Histogram', async () => {
-//       const stateContainer = getStateContainer();
-//       const { hook } = await renderUseDiscoverHistogram({ stateContainer });
-//       const api = createMockUnifiedHistogramApi();
-//       let params: Partial<UnifiedHistogramState> = {};
-//       api.setTotalHits = jest.fn((p) => {
-//         params = { ...params, ...p };
-//       });
-//       api.setChartHidden = jest.fn((chartHidden) => {
-//         params = { ...params, chartHidden };
-//       });
-//       api.setTimeInterval = jest.fn((timeInterval) => {
-//         params = { ...params, timeInterval };
-//       });
-//       api.setBreakdownField = jest.fn((breakdownField) => {
-//         params = { ...params, breakdownField };
-//       });
-//       act(() => {
-//         hook.result.current.ref(api);
-//       });
-//       stateContainer.appState.update({ hideChart: true, interval: '1m', breakdownField: 'test' });
-//       expect(api.setTotalHits).not.toHaveBeenCalled();
-//       expect(api.setChartHidden).toHaveBeenCalled();
-//       expect(api.setTimeInterval).toHaveBeenCalled();
-//       expect(api.setBreakdownField).toHaveBeenCalled();
-//       expect(Object.keys(params ?? {})).toEqual(['breakdownField', 'timeInterval', 'chartHidden']);
-//     });
+      mockData.query.getState = () => mockQueryState;
+      const stateContainer = getStateContainer();
+      const { hook } = await renderUseDiscoverHistogram({ stateContainer });
+      const containerState = stateContainer.appState.getState();
+      const error = new Error('test');
+      const state = {
+        timeInterval: containerState.interval,
+        chartHidden: containerState.hideChart,
+        totalHitsStatus: UnifiedHistogramFetchStatus.loading,
+        totalHitsResult: undefined,
+      } as unknown as UnifiedHistogramState;
+      const api = createMockUnifiedHistogramApi();
+      api.state$ = new BehaviorSubject({
+        ...state,
+        totalHitsStatus: UnifiedHistogramFetchStatus.error,
+        totalHitsResult: error,
+      });
+      expect(stateContainer.dataState.data$.totalHits$.value).not.toEqual({
+        fetchStatus: FetchStatus.ERROR,
+        error,
+      });
+      act(() => {
+        hook.result.current.ref(api);
+      });
+      expect(sendErrorTo).toHaveBeenCalledWith(stateContainer.dataState.data$.totalHits$);
+      expect(stateContainer.dataState.data$.totalHits$.value).toEqual({
+        fetchStatus: FetchStatus.ERROR,
+        error,
+      });
+      expect(mockCheckHitCount).not.toHaveBeenCalled();
+    });
 
-//     it('should exclude totalHitsStatus and totalHitsResult from Unified Histogram state updates', async () => {
-//       const stateContainer = getStateContainer();
-//       const { hook } = await renderUseDiscoverHistogram({ stateContainer });
-//       const containerState = stateContainer.appState.getState();
-//       const state = {
-//         timeInterval: containerState.interval,
-//         chartHidden: containerState.hideChart,
-//         breakdownField: containerState.breakdownField,
-//         totalHitsStatus: UnifiedHistogramFetchStatus.loading,
-//         totalHitsResult: undefined,
-//       } as unknown as UnifiedHistogramState;
-//       const api = createMockUnifiedHistogramApi();
-//       let params: Partial<UnifiedHistogramState> = {};
-//       api.setChartHidden = jest.fn((chartHidden) => {
-//         params = { ...params, chartHidden };
-//       });
-//       const subject$ = new BehaviorSubject(state);
-//       api.state$ = subject$;
-//       act(() => {
-//         hook.result.current.ref(api);
-//       });
-//       stateContainer.appState.update({ hideChart: true });
-//       expect(Object.keys(params ?? {})).toEqual(['chartHidden']);
-//       params = {};
-//       stateContainer.appState.update({ hideChart: false });
-//       act(() => {
-//         subject$.next({
-//           ...state,
-//           totalHitsStatus: UnifiedHistogramFetchStatus.complete,
-//           totalHitsResult: 100,
-//         });
-//       });
-//       expect(Object.keys(params ?? {})).toEqual(['chartHidden']);
-//     });
+    it('should set isChartLoading to true for fetch start', async () => {
+      const fetch$ = new Subject<void>();
+      const stateContainer = getStateContainer();
+      stateContainer.appState.update({ query: { esql: 'from *' } });
+      stateContainer.dataState.fetchChart$ = fetch$;
+      const { hook } = await renderUseDiscoverHistogram({ stateContainer });
+      act(() => {
+        fetch$.next();
+      });
+      expect(hook.result.current.isChartLoading).toBe(true);
+    });
+  });
 
-//     it('should update total hits when the total hits state changes', async () => {
-//       const stateContainer = getStateContainer();
-//       const { hook } = await renderUseDiscoverHistogram({ stateContainer });
-//       const containerState = stateContainer.appState.getState();
-//       const state = {
-//         timeInterval: containerState.interval,
-//         chartHidden: containerState.hideChart,
-//         breakdownField: containerState.breakdownField,
-//         totalHitsStatus: UnifiedHistogramFetchStatus.loading,
-//         totalHitsResult: undefined,
-//       } as unknown as UnifiedHistogramState;
-//       const api = createMockUnifiedHistogramApi();
-//       api.state$ = new BehaviorSubject({
-//         ...state,
-//         totalHitsStatus: UnifiedHistogramFetchStatus.complete,
-//         totalHitsResult: 100,
-//       });
-//       expect(stateContainer.dataState.data$.totalHits$.value).not.toEqual({
-//         fetchStatus: FetchStatus.COMPLETE,
-//         result: 100,
-//       });
-//       act(() => {
-//         hook.result.current.ref(api);
-//       });
-//       expect(stateContainer.dataState.data$.totalHits$.value).toEqual({
-//         fetchStatus: FetchStatus.COMPLETE,
-//         result: 100,
-//       });
-//       expect(mockCheckHitCount).toHaveBeenCalledWith(stateContainer.dataState.data$.main$, 100);
-//     });
+  describe('refetching', () => {
+    it('should call refetch when savedSearchFetch$ is triggered', async () => {
+      const savedSearchFetch$ = new Subject<void>();
+      const stateContainer = getStateContainer();
+      stateContainer.dataState.fetchChart$ = savedSearchFetch$;
+      const { hook } = await renderUseDiscoverHistogram({ stateContainer });
+      const api = createMockUnifiedHistogramApi();
+      act(() => {
+        hook.result.current.ref(api);
+      });
+      expect(api.refetch).toHaveBeenCalled();
+      act(() => {
+        savedSearchFetch$.next();
+      });
+      expect(api.refetch).toHaveBeenCalledTimes(2);
+    });
 
-//     it('should not update total hits when the total hits state changes to an error', async () => {
-//       mockQueryState = {
-//         query: {
-//           query: 'query',
-//           language: 'kuery',
-//         } as Query | AggregateQuery,
-//         filters: [],
-//         time: {
-//           from: 'now-15m',
-//           to: 'now',
-//         },
-//       };
+    it('should skip the next refetch when hideChart changes from true to false', async () => {
+      const savedSearchFetch$ = new Subject<void>();
+      const stateContainer = getStateContainer();
+      stateContainer.dataState.fetchChart$ = savedSearchFetch$;
+      const { hook, initialProps } = await renderUseDiscoverHistogram({ stateContainer });
+      const api = createMockUnifiedHistogramApi();
+      act(() => {
+        hook.result.current.ref(api);
+      });
+      expect(api.refetch).toHaveBeenCalled();
+      act(() => {
+        hook.rerender({ ...initialProps, hideChart: true });
+      });
+      act(() => {
+        hook.rerender({ ...initialProps, hideChart: false });
+      });
+      act(() => {
+        savedSearchFetch$.next();
+      });
+      expect(api.refetch).toHaveBeenCalledTimes(1);
+    });
+  });
 
-//       mockData.query.getState = () => mockQueryState;
-//       const stateContainer = getStateContainer();
-//       const { hook } = await renderUseDiscoverHistogram({ stateContainer });
-//       const containerState = stateContainer.appState.getState();
-//       const error = new Error('test');
-//       const state = {
-//         timeInterval: containerState.interval,
-//         chartHidden: containerState.hideChart,
-//         breakdownField: containerState.breakdownField,
-//         totalHitsStatus: UnifiedHistogramFetchStatus.loading,
-//         totalHitsResult: undefined,
-//       } as unknown as UnifiedHistogramState;
-//       const api = createMockUnifiedHistogramApi();
-//       api.state$ = new BehaviorSubject({
-//         ...state,
-//         totalHitsStatus: UnifiedHistogramFetchStatus.error,
-//         totalHitsResult: error,
-//       });
-//       expect(stateContainer.dataState.data$.totalHits$.value).not.toEqual({
-//         fetchStatus: FetchStatus.ERROR,
-//         error,
-//       });
-//       act(() => {
-//         hook.result.current.ref(api);
-//       });
-//       expect(sendErrorTo).toHaveBeenCalledWith(stateContainer.dataState.data$.totalHits$);
-//       expect(stateContainer.dataState.data$.totalHits$.value).toEqual({
-//         fetchStatus: FetchStatus.ERROR,
-//         error,
-//       });
-//       expect(mockCheckHitCount).not.toHaveBeenCalled();
-//     });
+  describe('customization', () => {
+    test('should use custom values provided by customization fwk ', async () => {
+      mockUseCustomizations = true;
+      const stateContainer = getStateContainer();
+      const { hook } = await renderUseDiscoverHistogram({ stateContainer });
 
-//     it('should set isChartLoading to true for fetch start', async () => {
-//       const fetch$ = new Subject<{
-//         options: {
-//           reset: boolean;
-//           fetchMore: boolean;
-//         };
-//         searchSessionId: string;
-//       }>();
-//       const stateContainer = getStateContainer();
-//       stateContainer.appState.update({ query: { esql: 'from *' } });
-//       stateContainer.dataState.fetch$ = fetch$;
-//       const { hook } = await renderUseDiscoverHistogram({ stateContainer });
-//       act(() => {
-//         fetch$.next({
-//           options: { reset: false, fetchMore: false },
-//           searchSessionId: '1234',
-//         });
-//       });
-//       expect(hook.result.current.isChartLoading).toBe(true);
-//     });
-//   });
-
-//   describe('refetching', () => {
-//     it('should call refetch when savedSearchFetch$ is triggered', async () => {
-//       const savedSearchFetch$ = new Subject<{
-//         options: {
-//           reset: boolean;
-//           fetchMore: boolean;
-//         };
-//         searchSessionId: string;
-//       }>();
-//       const stateContainer = getStateContainer();
-//       stateContainer.dataState.fetch$ = savedSearchFetch$;
-//       const { hook } = await renderUseDiscoverHistogram({ stateContainer });
-//       const api = createMockUnifiedHistogramApi();
-//       act(() => {
-//         hook.result.current.ref(api);
-//       });
-//       expect(api.refetch).toHaveBeenCalled();
-//       act(() => {
-//         savedSearchFetch$.next({
-//           options: { reset: false, fetchMore: false },
-//           searchSessionId: '1234',
-//         });
-//       });
-//       expect(api.refetch).toHaveBeenCalledTimes(2);
-//     });
-
-//     it('should skip the next refetch when hideChart changes from true to false', async () => {
-//       const savedSearchFetch$ = new Subject<{
-//         options: {
-//           reset: boolean;
-//           fetchMore: boolean;
-//         };
-//         searchSessionId: string;
-//       }>();
-//       const stateContainer = getStateContainer();
-//       stateContainer.dataState.fetch$ = savedSearchFetch$;
-//       const { hook, initialProps } = await renderUseDiscoverHistogram({ stateContainer });
-//       const api = createMockUnifiedHistogramApi();
-//       act(() => {
-//         hook.result.current.ref(api);
-//       });
-//       expect(api.refetch).toHaveBeenCalled();
-//       act(() => {
-//         hook.rerender({ ...initialProps, hideChart: true });
-//       });
-//       act(() => {
-//         hook.rerender({ ...initialProps, hideChart: false });
-//       });
-//       act(() => {
-//         savedSearchFetch$.next({
-//           options: { reset: false, fetchMore: false },
-//           searchSessionId: '1234',
-//         });
-//       });
-//       expect(api.refetch).toHaveBeenCalledTimes(1);
-//     });
-
-//     it('should skip the next refetch when fetching more', async () => {
-//       const savedSearchFetch$ = new Subject<{
-//         options: {
-//           reset: boolean;
-//           fetchMore: boolean;
-//         };
-//         searchSessionId: string;
-//       }>();
-//       const stateContainer = getStateContainer();
-//       stateContainer.dataState.fetch$ = savedSearchFetch$;
-//       const { hook } = await renderUseDiscoverHistogram({ stateContainer });
-//       const api = createMockUnifiedHistogramApi();
-//       act(() => {
-//         hook.result.current.ref(api);
-//       });
-//       expect(api.refetch).toHaveBeenCalledTimes(1);
-//       act(() => {
-//         savedSearchFetch$.next({
-//           options: { reset: false, fetchMore: true },
-//           searchSessionId: '1234',
-//         });
-//       });
-//       expect(api.refetch).toHaveBeenCalledTimes(1);
-
-//       act(() => {
-//         savedSearchFetch$.next({
-//           options: { reset: false, fetchMore: false },
-//           searchSessionId: '1234',
-//         });
-//       });
-//       expect(api.refetch).toHaveBeenCalledTimes(2);
-//     });
-//   });
-
-//   describe('customization', () => {
-//     test('should use custom values provided by customization fwk ', async () => {
-//       mockUseCustomizations = true;
-//       const stateContainer = getStateContainer();
-//       const { hook } = await renderUseDiscoverHistogram({ stateContainer });
-
-//       expect(hook.result.current.onFilter).toEqual(mockHistogramCustomization.onFilter);
-//       expect(hook.result.current.onBrushEnd).toEqual(mockHistogramCustomization.onBrushEnd);
-//       expect(hook.result.current.withDefaultActions).toEqual(
-//         mockHistogramCustomization.withDefaultActions
-//       );
-//       expect(hook.result.current.disabledActions).toBeUndefined();
-//     });
-//   });
-// });
+      expect(hook.result.current.onFilter).toEqual(mockHistogramCustomization.onFilter);
+      expect(hook.result.current.onBrushEnd).toEqual(mockHistogramCustomization.onBrushEnd);
+      expect(hook.result.current.withDefaultActions).toEqual(
+        mockHistogramCustomization.withDefaultActions
+      );
+      expect(hook.result.current.disabledActions).toBeUndefined();
+    });
+  });
+});

--- a/src/plugins/discover/public/application/main/components/layout/use_discover_histogram.ts
+++ b/src/plugins/discover/public/application/main/components/layout/use_discover_histogram.ts
@@ -12,13 +12,14 @@ import {
   canImportVisContext,
   UnifiedHistogramApi,
   UnifiedHistogramContainerProps,
+  UnifiedHistogramCreationOptions,
   UnifiedHistogramExternalVisContextStatus,
   UnifiedHistogramFetchStatus,
   UnifiedHistogramState,
   UnifiedHistogramVisContext,
 } from '@kbn/unified-histogram-plugin/public';
 import { isEqual } from 'lodash';
-import { RefAttributes, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
   debounceTime,
   distinctUntilChanged,
@@ -63,8 +64,13 @@ export const useDiscoverHistogram = ({
   stateContainer,
   inspectorAdapters,
   hideChart,
-}: UseDiscoverHistogramProps): Omit<UnifiedHistogramContainerProps, 'container'> &
-  RefAttributes<UnifiedHistogramApi> => {
+}: UseDiscoverHistogramProps): Omit<
+  UnifiedHistogramContainerProps,
+  'container' | 'getCreationOptions'
+> & {
+  ref: (api: UnifiedHistogramApi | null) => void;
+  getCreationOptions: () => UnifiedHistogramCreationOptions;
+} => {
   const services = useDiscoverServices();
   const { main$, documents$, totalHits$ } = stateContainer.dataState.data$;
   const savedSearchState = useSavedSearch();

--- a/src/plugins/discover/public/application/main/data_fetching/fetch_all.ts
+++ b/src/plugins/discover/public/application/main/data_fetching/fetch_all.ts
@@ -9,7 +9,15 @@
 
 import { Adapters } from '@kbn/inspector-plugin/common';
 import type { SavedSearch, SortOrder } from '@kbn/saved-search-plugin/public';
-import { BehaviorSubject, combineLatest, filter, firstValueFrom, switchMap } from 'rxjs';
+import {
+  BehaviorSubject,
+  combineLatest,
+  distinctUntilChanged,
+  filter,
+  firstValueFrom,
+  race,
+  switchMap,
+} from 'rxjs';
 import { reportPerformanceMetricEvent } from '@kbn/ebt-tools';
 import { isEqual } from 'lodash';
 import { isOfAggregateQueryType } from '@kbn/es-query';
@@ -27,7 +35,11 @@ import {
 } from '../hooks/use_saved_search_messages';
 import { fetchDocuments } from './fetch_documents';
 import { FetchStatus } from '../../types';
-import { DataMsg, SavedSearchData } from '../state_management/discover_data_state_container';
+import {
+  DataMain$,
+  DataMsg,
+  SavedSearchData,
+} from '../state_management/discover_data_state_container';
 import { DiscoverServices } from '../../../build_services';
 import { fetchEsql } from './fetch_esql';
 import { InternalState } from '../state_management/discover_internal_state_container';
@@ -173,12 +185,17 @@ export function fetchAll(
       // but their errors will be shown in-place (e.g. of the chart).
       .catch(sendErrorTo(dataSubjects.documents$, dataSubjects.main$));
 
-    // Return a promise that will resolve once all the requests have finished or failed
+    // Return a promise that will resolve once all the requests have finished or failed, or no results are found
     return firstValueFrom(
-      combineLatest([
-        isComplete(dataSubjects.documents$).pipe(switchMap(async () => onFetchRecordsComplete?.())),
-        isComplete(dataSubjects.totalHits$),
-      ])
+      race(
+        combineLatest([
+          isComplete(dataSubjects.documents$).pipe(
+            switchMap(async () => onFetchRecordsComplete?.())
+          ),
+          isComplete(dataSubjects.totalHits$),
+        ]),
+        noResultsFound(dataSubjects.main$)
+      )
     ).then(() => {
       // Send a complete message to main$ once all queries are done and if main$
       // is not already in an ERROR state, e.g. because the document query has failed.
@@ -250,6 +267,18 @@ export async function fetchMoreDocuments(
 
 const isComplete = <T extends DataMsg>(subject: BehaviorSubject<T>) => {
   return subject.pipe(
-    filter(({ fetchStatus }) => [FetchStatus.COMPLETE, FetchStatus.ERROR].includes(fetchStatus))
+    filter(({ fetchStatus }) => [FetchStatus.COMPLETE, FetchStatus.ERROR].includes(fetchStatus)),
+    distinctUntilChanged((a, b) => a.fetchStatus === b.fetchStatus)
+  );
+};
+
+const noResultsFound = (subject: DataMain$) => {
+  return subject.pipe(
+    filter(
+      ({ fetchStatus, foundDocuments }) => fetchStatus === FetchStatus.COMPLETE && !foundDocuments
+    ),
+    distinctUntilChanged(
+      (a, b) => a.fetchStatus === b.fetchStatus && a.foundDocuments === b.foundDocuments
+    )
   );
 };

--- a/src/plugins/discover/public/application/main/hooks/use_esql_mode.test.tsx
+++ b/src/plugins/discover/public/application/main/hooks/use_esql_mode.test.tsx
@@ -30,7 +30,8 @@ import { buildDataTableRecord, EsHitRecord } from '@kbn/discover-utils';
 function getHookProps(
   query: AggregateQuery | Query | undefined,
   dataViewsService?: DataViewsContract,
-  appState?: Partial<DiscoverAppState>
+  appState?: Partial<DiscoverAppState>,
+  defaultFetchStatus: FetchStatus = FetchStatus.PARTIAL
 ) {
   const replaceUrlState = jest.fn();
   const stateContainer = getDiscoverStateMock({ isTimeBased: true });
@@ -39,7 +40,7 @@ function getHookProps(
   stateContainer.internalState.transitions.setSavedDataViews([dataViewMock as DataViewListItem]);
 
   const msgLoading = {
-    fetchStatus: FetchStatus.PARTIAL,
+    fetchStatus: defaultFetchStatus,
     query,
   };
   stateContainer.dataState.data$.documents$.next(msgLoading);
@@ -82,15 +83,16 @@ const getHookContext = (stateContainer: DiscoverStateContainer) => {
 };
 const renderHookWithContext = (
   useDataViewsService: boolean = false,
-  appState?: DiscoverAppState
+  appState?: DiscoverAppState,
+  defaultFetchStatus?: FetchStatus
 ) => {
-  const props = getHookProps(query, useDataViewsService ? getDataViewsService() : undefined);
+  const props = getHookProps(
+    query,
+    useDataViewsService ? getDataViewsService() : undefined,
+    appState,
+    defaultFetchStatus
+  );
   props.stateContainer.actions.setDataView(dataViewMock);
-  if (appState) {
-    props.stateContainer.appState.getState = jest.fn(() => {
-      return appState;
-    });
-  }
 
   renderHook(() => useEsqlMode(props), {
     wrapper: getHookContext(props.stateContainer),
@@ -492,7 +494,11 @@ describe('useEsqlMode', () => {
   });
 
   it('should call setResetDefaultProfileState correctly when index pattern changes', async () => {
-    const { stateContainer } = renderHookWithContext(false);
+    const { stateContainer } = renderHookWithContext(
+      false,
+      { query: { esql: 'from pattern' } },
+      FetchStatus.LOADING
+    );
     const documents$ = stateContainer.dataState.data$.documents$;
     expect(stateContainer.internalState.get().resetDefaultProfileState).toEqual({
       columns: false,
@@ -501,6 +507,11 @@ describe('useEsqlMode', () => {
     });
     documents$.next({
       fetchStatus: FetchStatus.PARTIAL,
+      query: { esql: 'from pattern' },
+    });
+    stateContainer.appState.update({ query: { esql: 'from pattern1' } });
+    documents$.next({
+      fetchStatus: FetchStatus.LOADING,
       query: { esql: 'from pattern1' },
     });
     await waitFor(() =>
@@ -510,13 +521,18 @@ describe('useEsqlMode', () => {
         breakdownField: true,
       })
     );
+    documents$.next({
+      fetchStatus: FetchStatus.PARTIAL,
+      query: { esql: 'from pattern1' },
+    });
     stateContainer.internalState.transitions.setResetDefaultProfileState({
       columns: false,
       rowHeight: false,
       breakdownField: false,
     });
+    stateContainer.appState.update({ query: { esql: 'from pattern1' } });
     documents$.next({
-      fetchStatus: FetchStatus.PARTIAL,
+      fetchStatus: FetchStatus.LOADING,
       query: { esql: 'from pattern1' },
     });
     await waitFor(() =>
@@ -528,6 +544,11 @@ describe('useEsqlMode', () => {
     );
     documents$.next({
       fetchStatus: FetchStatus.PARTIAL,
+      query: { esql: 'from pattern1' },
+    });
+    stateContainer.appState.update({ query: { esql: 'from pattern2' } });
+    documents$.next({
+      fetchStatus: FetchStatus.LOADING,
       query: { esql: 'from pattern2' },
     });
     await waitFor(() =>
@@ -537,6 +558,10 @@ describe('useEsqlMode', () => {
         breakdownField: true,
       })
     );
+    documents$.next({
+      fetchStatus: FetchStatus.PARTIAL,
+      query: { esql: 'from pattern2' },
+    });
   });
 
   it('should call setResetDefaultProfileState correctly when columns change', async () => {
@@ -545,23 +570,6 @@ describe('useEsqlMode', () => {
     const result1 = [buildDataTableRecord({ message: 'foo' } as EsHitRecord)];
     const result2 = [buildDataTableRecord({ message: 'foo', extension: 'bar' } as EsHitRecord)];
     expect(stateContainer.internalState.get().resetDefaultProfileState).toEqual({
-      columns: false,
-      rowHeight: false,
-      breakdownField: false,
-    });
-    documents$.next({
-      fetchStatus: FetchStatus.PARTIAL,
-      query: { esql: 'from pattern' },
-      result: result1,
-    });
-    await waitFor(() =>
-      expect(stateContainer.internalState.get().resetDefaultProfileState).toEqual({
-        columns: true,
-        rowHeight: true,
-        breakdownField: true,
-      })
-    );
-    stateContainer.internalState.transitions.setResetDefaultProfileState({
       columns: false,
       rowHeight: false,
       breakdownField: false,
@@ -587,7 +595,7 @@ describe('useEsqlMode', () => {
       expect(stateContainer.internalState.get().resetDefaultProfileState).toEqual({
         columns: true,
         rowHeight: false,
-        breakdownField: true,
+        breakdownField: false,
       })
     );
   });

--- a/src/plugins/discover/public/application/main/state_management/discover_data_state_container.ts
+++ b/src/plugins/discover/public/application/main/state_management/discover_data_state_container.ts
@@ -44,13 +44,6 @@ export interface SavedSearchData {
 export type DataMain$ = BehaviorSubject<DataMainMsg>;
 export type DataDocuments$ = BehaviorSubject<DataDocumentsMsg>;
 export type DataTotalHits$ = BehaviorSubject<DataTotalHitsMsg>;
-export type DataFetch$ = Observable<{
-  options: {
-    reset: boolean;
-    fetchMore: boolean;
-  };
-  searchSessionId: string;
-}>;
 
 export type DataRefetch$ = Subject<DataRefetchMsg>;
 
@@ -95,10 +88,6 @@ export interface DiscoverDataStateContainer {
    */
   fetchMore: () => void;
   /**
-   * Observable emitting when a next fetch is triggered
-   */
-  fetch$: DataFetch$;
-  /**
    * Container of data observables (orchestration, data table, total hits, available fields)
    */
   data$: SavedSearchData;
@@ -106,6 +95,14 @@ export interface DiscoverDataStateContainer {
    * Observable triggering fetching data from ES
    */
   refetch$: DataRefetch$;
+  /**
+   * Emits when the chart should be fetched
+   */
+  fetchChart$: Observable<void>;
+  /**
+   * Used to disable the next fetch that would otherwise be triggered by a URL state change
+   */
+  disableNextFetchOnStateChange$: BehaviorSubject<boolean>;
   /**
    * Start subscribing to other observables that trigger data fetches
    */
@@ -159,6 +156,8 @@ export function getDataStateContainer({
   const { data, uiSettings, toastNotifications, profilesManager } = services;
   const { timefilter } = data.query.timefilter;
   const inspectorAdapters = { requests: new RequestAdapter() };
+  const fetchChart$ = new Subject<void>();
+  const disableNextFetchOnStateChange$ = new BehaviorSubject(false);
 
   /**
    * The observable to trigger data fetching in UI
@@ -266,6 +265,20 @@ export function getDataStateContainer({
             query: appStateContainer.getState().query,
           });
 
+          const { resetDefaultProfileState, dataView } = internalStateContainer.getState();
+          const defaultProfileState = dataView
+            ? getDefaultProfileState({ profilesManager, resetDefaultProfileState, dataView })
+            : undefined;
+          const preFetchStateUpdate = defaultProfileState?.getPreFetchState();
+
+          if (preFetchStateUpdate) {
+            disableNextFetchOnStateChange$.next(true);
+            await appStateContainer.replaceUrlState(preFetchStateUpdate);
+            disableNextFetchOnStateChange$.next(false);
+          }
+
+          fetchChart$.next();
+
           abortController = new AbortController();
           const prevAutoRefreshDone = autoRefreshDone;
           const fetchAllStartTime = window.performance.now();
@@ -278,37 +291,22 @@ export function getDataStateContainer({
               ...commonFetchDeps,
             },
             async () => {
-              const { resetDefaultProfileState, dataView } = internalStateContainer.getState();
               const { esqlQueryColumns } = dataSubjects.documents$.getValue();
               const defaultColumns = uiSettings.get<string[]>(DEFAULT_COLUMNS_SETTING, []);
-              const clearResetProfileState = () => {
-                internalStateContainer.transitions.setResetDefaultProfileState({
-                  columns: false,
-                  rowHeight: false,
-                  breakdownField: false,
-                });
-              };
-
-              if (!dataView) {
-                clearResetProfileState();
-                return;
-              }
-
-              const stateUpdate = getDefaultProfileState({
-                profilesManager,
-                resetDefaultProfileState,
+              const postFetchStateUpdate = defaultProfileState?.getPostFetchState({
                 defaultColumns,
-                dataView,
                 esqlQueryColumns,
               });
 
-              if (!stateUpdate) {
-                clearResetProfileState();
-                return;
+              if (postFetchStateUpdate) {
+                await appStateContainer.replaceUrlState(postFetchStateUpdate);
               }
 
-              await appStateContainer.replaceUrlState(stateUpdate);
-              clearResetProfileState();
+              internalStateContainer.transitions.setResetDefaultProfileState({
+                columns: false,
+                rowHeight: false,
+                breakdownField: false,
+              });
             }
           );
 
@@ -378,9 +376,10 @@ export function getDataStateContainer({
   return {
     fetch: fetchQuery,
     fetchMore,
-    fetch$,
     data$: dataSubjects,
     refetch$,
+    fetchChart$,
+    disableNextFetchOnStateChange$,
     subscribe,
     reset,
     inspectorAdapters,

--- a/src/plugins/discover/public/application/main/state_management/discover_data_state_container.ts
+++ b/src/plugins/discover/public/application/main/state_management/discover_data_state_container.ts
@@ -277,6 +277,8 @@ export function getDataStateContainer({
             disableNextFetchOnStateChange$.next(false);
           }
 
+          // Trigger chart fetching after the pre fetch state has been updated
+          // to ensure state values that would affect data fetching are set
           fetchChart$.next();
 
           abortController = new AbortController();
@@ -302,6 +304,8 @@ export function getDataStateContainer({
                 await appStateContainer.replaceUrlState(postFetchStateUpdate);
               }
 
+              // Clear the default profile state flags after the data fetching
+              // is done so refetches don't reset the state again
               internalStateContainer.transitions.setResetDefaultProfileState({
                 columns: false,
                 rowHeight: false,

--- a/src/plugins/discover/public/application/main/state_management/discover_state.test.ts
+++ b/src/plugins/discover/public/application/main/state_management/discover_state.test.ts
@@ -26,7 +26,7 @@ import { discoverServiceMock } from '../../../__mocks__/services';
 import { dataViewMock } from '@kbn/discover-utils/src/__mocks__';
 import type { DiscoverAppStateContainer } from './discover_app_state_container';
 import { waitFor } from '@testing-library/react';
-// import { FetchStatus } from '../../types';
+import { FetchStatus } from '../../types';
 import { dataViewAdHoc, dataViewComplexMock } from '../../../__mocks__/data_view_complex';
 import { copySavedSearch } from './discover_saved_search_container';
 import { createKbnUrlStateStorage, IKbnUrlStateStorage } from '@kbn/kibana-utils-plugin/public';
@@ -99,10 +99,12 @@ describe('Test discover state', () => {
     state.appState.update({}, true);
     stopSync = startSync(state.appState);
   });
+
   afterEach(() => {
     stopSync();
     stopSync = () => {};
   });
+
   test('setting app state and syncing to URL', async () => {
     state.appState.update({
       dataSource: createDataViewDataSource({ dataViewId: 'modified' }),
@@ -124,6 +126,7 @@ describe('Test discover state', () => {
       }
     `);
   });
+
   test('URL navigation to url without _a, state should not change', async () => {
     history.push('/#?_a=(dataSource:(dataViewId:modified,type:dataView))');
     history.push('/');
@@ -241,6 +244,7 @@ describe('Test discover initial state sort handling', () => {
     expect(state.appState.getState().sort).toEqual([['timestamp', 'desc']]);
     unsubscribe();
   });
+
   test('Empty URL should use saved search sort for state', async () => {
     const nextSavedSearch = { ...savedSearchMock, ...{ sort: [['bytes', 'desc']] as SortOrder[] } };
     const { state } = await getState('/', { savedSearch: nextSavedSearch });
@@ -420,26 +424,28 @@ describe('Test discover state actions', () => {
     expect(state.internalState.getState().dataView).toBe(dataViewMock);
   });
 
-  // test('fetchData', async () => {
-  //   const { state } = await getState('/');
-  //   const dataState = state.dataState;
-  //   await state.actions.loadDataViewList();
-  //   expect(dataState.data$.main$.value.fetchStatus).toBe(FetchStatus.LOADING);
-  //   await state.actions.loadSavedSearch();
-  //   const unsubscribe = state.actions.initializeAndSync();
-  //   state.actions.fetchData();
-  //   await waitFor(() => {
-  //     expect(dataState.data$.documents$.value.fetchStatus).toBe(FetchStatus.COMPLETE);
-  //   });
-  //   unsubscribe();
+  test('fetchData', async () => {
+    const { state } = await getState('/');
+    const dataState = state.dataState;
+    await state.actions.loadDataViewList();
+    expect(dataState.data$.main$.value.fetchStatus).toBe(FetchStatus.LOADING);
+    await state.actions.loadSavedSearch();
+    const unsubscribe = state.actions.initializeAndSync();
+    state.actions.fetchData();
+    await waitFor(() => {
+      expect(dataState.data$.documents$.value.fetchStatus).toBe(FetchStatus.COMPLETE);
+    });
+    unsubscribe();
 
-  //   expect(dataState.data$.totalHits$.value.result).toBe(0);
-  //   expect(dataState.data$.documents$.value.result).toEqual([]);
-  // });
+    expect(dataState.data$.totalHits$.value.result).toBe(0);
+    expect(dataState.data$.documents$.value.result).toEqual([]);
+  });
+
   test('loadDataViewList', async () => {
     const { state } = await getState('');
     expect(state.internalState.getState().savedDataViews.length).toBe(3);
   });
+
   test('loadSavedSearch with no id given an empty URL', async () => {
     const { state, getCurrentUrl } = await getState('');
     await state.actions.loadDataViewList();
@@ -486,6 +492,7 @@ describe('Test discover state actions', () => {
     expect(state.savedSearchState.getHasChanged$().getValue()).toBe(false);
     unsubscribe();
   });
+
   test('loadNewSavedSearch with URL changing interval state', async () => {
     const { state, getCurrentUrl } = await getState(
       '/#?_a=(interval:month,columns:!(bytes))&_g=()',
@@ -501,6 +508,7 @@ describe('Test discover state actions', () => {
     expect(state.savedSearchState.getHasChanged$().getValue()).toBe(true);
     unsubscribe();
   });
+
   test('loadSavedSearch with no id, given URL changes state', async () => {
     const { state, getCurrentUrl } = await getState(
       '/#?_a=(interval:month,columns:!(bytes))&_g=()',
@@ -516,6 +524,7 @@ describe('Test discover state actions', () => {
     expect(state.savedSearchState.getHasChanged$().getValue()).toBe(true);
     unsubscribe();
   });
+
   test('loadSavedSearch given an empty URL, no state changes', async () => {
     const { state, getCurrentUrl } = await getState('/', { savedSearch: savedSearchMock });
     const newSavedSearch = await state.actions.loadSavedSearch({
@@ -530,6 +539,7 @@ describe('Test discover state actions', () => {
     expect(state.savedSearchState.getHasChanged$().getValue()).toBe(false);
     unsubscribe();
   });
+
   test('loadSavedSearch given a URL with different interval and columns modifying the state', async () => {
     const url = '/#?_a=(interval:month,columns:!(message))&_g=()';
     const { state, getCurrentUrl } = await getState(url, {
@@ -683,6 +693,7 @@ describe('Test discover state actions', () => {
     );
     expect(state.savedSearchState.getHasChanged$().getValue()).toBe(true);
   });
+
   test('loadSavedSearch generating a new saved search, updated by ad-hoc data view', async () => {
     const { state } = await getState('/');
     const dataViewSpecMock = {
@@ -810,6 +821,7 @@ describe('Test discover state actions', () => {
     expect(getCurrentUrl()).toContain(dataViewComplexMock.id);
     unsubscribe();
   });
+
   test('onDataViewCreated - persisted data view', async () => {
     const { state } = await getState('/', { savedSearch: savedSearchMock });
     await state.actions.loadSavedSearch({ savedSearchId: savedSearchMock.id });
@@ -826,6 +838,7 @@ describe('Test discover state actions', () => {
     );
     unsubscribe();
   });
+
   test('onDataViewCreated - ad-hoc data view', async () => {
     const { state } = await getState('/', { savedSearch: savedSearchMock });
     await state.actions.loadSavedSearch({ savedSearchId: savedSearchMock.id });
@@ -842,6 +855,7 @@ describe('Test discover state actions', () => {
     );
     unsubscribe();
   });
+
   test('onDataViewEdited - persisted data view', async () => {
     const { state } = await getState('/', { savedSearch: savedSearchMock });
     await state.actions.loadSavedSearch({ savedSearchId: savedSearchMock.id });
@@ -857,6 +871,7 @@ describe('Test discover state actions', () => {
     });
     unsubscribe();
   });
+
   test('onDataViewEdited - ad-hoc data view', async () => {
     const { state } = await getState('/', { savedSearch: savedSearchMock });
     const unsubscribe = state.actions.initializeAndSync();
@@ -903,6 +918,7 @@ describe('Test discover state actions', () => {
     expect(state.internalState.getState().adHocDataViews[0].id).toBe('ad-hoc-id');
     unsubscribe();
   });
+
   test('undoSavedSearchChanges - when changing data views', async () => {
     const { state, getCurrentUrl } = await getState('/', { savedSearch: savedSearchMock });
     // Load a given persisted saved search

--- a/src/plugins/discover/public/application/main/state_management/discover_state.test.ts
+++ b/src/plugins/discover/public/application/main/state_management/discover_state.test.ts
@@ -26,7 +26,7 @@ import { discoverServiceMock } from '../../../__mocks__/services';
 import { dataViewMock } from '@kbn/discover-utils/src/__mocks__';
 import type { DiscoverAppStateContainer } from './discover_app_state_container';
 import { waitFor } from '@testing-library/react';
-import { FetchStatus } from '../../types';
+// import { FetchStatus } from '../../types';
 import { dataViewAdHoc, dataViewComplexMock } from '../../../__mocks__/data_view_complex';
 import { copySavedSearch } from './discover_saved_search_container';
 import { createKbnUrlStateStorage, IKbnUrlStateStorage } from '@kbn/kibana-utils-plugin/public';
@@ -420,22 +420,22 @@ describe('Test discover state actions', () => {
     expect(state.internalState.getState().dataView).toBe(dataViewMock);
   });
 
-  test('fetchData', async () => {
-    const { state } = await getState('/');
-    const dataState = state.dataState;
-    await state.actions.loadDataViewList();
-    expect(dataState.data$.main$.value.fetchStatus).toBe(FetchStatus.LOADING);
-    await state.actions.loadSavedSearch();
-    const unsubscribe = state.actions.initializeAndSync();
-    state.actions.fetchData();
-    await waitFor(() => {
-      expect(dataState.data$.documents$.value.fetchStatus).toBe(FetchStatus.COMPLETE);
-    });
-    unsubscribe();
+  // test('fetchData', async () => {
+  //   const { state } = await getState('/');
+  //   const dataState = state.dataState;
+  //   await state.actions.loadDataViewList();
+  //   expect(dataState.data$.main$.value.fetchStatus).toBe(FetchStatus.LOADING);
+  //   await state.actions.loadSavedSearch();
+  //   const unsubscribe = state.actions.initializeAndSync();
+  //   state.actions.fetchData();
+  //   await waitFor(() => {
+  //     expect(dataState.data$.documents$.value.fetchStatus).toBe(FetchStatus.COMPLETE);
+  //   });
+  //   unsubscribe();
 
-    expect(dataState.data$.totalHits$.value.result).toBe(0);
-    expect(dataState.data$.documents$.value.result).toEqual([]);
-  });
+  //   expect(dataState.data$.totalHits$.value.result).toBe(0);
+  //   expect(dataState.data$.documents$.value.result).toEqual([]);
+  // });
   test('loadDataViewList', async () => {
     const { state } = await getState('');
     expect(state.internalState.getState().savedDataViews.length).toBe(3);

--- a/src/plugins/discover/public/application/main/state_management/utils/build_state_subscribe.ts
+++ b/src/plugins/discover/public/application/main/state_management/utils/build_state_subscribe.ts
@@ -160,7 +160,7 @@ export const buildStateSubscribe =
 
       if (dataState.disableNextFetchOnStateChange$.getValue()) {
         addLog(
-          '[buildStateSubscribe] fetch disabled on state changes',
+          '[buildStateSubscribe] next fetch skipped on state change',
           JSON.stringify(logData, null, 2)
         );
 

--- a/src/plugins/discover/public/application/main/state_management/utils/build_state_subscribe.ts
+++ b/src/plugins/discover/public/application/main/state_management/utils/build_state_subscribe.ts
@@ -158,6 +158,17 @@ export const buildStateSubscribe =
         queryChanged: logEntry(queryChanged, prevQuery, nextQuery),
       };
 
+      if (dataState.disableNextFetchOnStateChange$.getValue()) {
+        addLog(
+          '[buildStateSubscribe] fetch disabled on state changes',
+          JSON.stringify(logData, null, 2)
+        );
+
+        dataState.disableNextFetchOnStateChange$.next(false);
+
+        return;
+      }
+
       addLog(
         '[buildStateSubscribe] state changes triggers data fetching',
         JSON.stringify(logData, null, 2)

--- a/src/plugins/discover/public/application/main/state_management/utils/get_default_profile_state.test.ts
+++ b/src/plugins/discover/public/application/main/state_management/utils/get_default_profile_state.test.ts
@@ -7,118 +7,122 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { fieldList } from '@kbn/data-views-plugin/common';
-import { buildDataViewMock } from '@kbn/discover-utils/src/__mocks__';
-import { createContextAwarenessMocks } from '../../../../context_awareness/__mocks__';
-import { dataViewWithTimefieldMock } from '../../../../__mocks__/data_view_with_timefield';
-import { getDefaultProfileState } from './get_default_profile_state';
-
-const emptyDataView = buildDataViewMock({
-  name: 'emptyDataView',
-  fields: fieldList(),
-});
-const { profilesManagerMock } = createContextAwarenessMocks();
-
-profilesManagerMock.resolveDataSourceProfile({});
-
 describe('getDefaultProfileState', () => {
-  it('should return expected columns', () => {
-    let appState = getDefaultProfileState({
-      profilesManager: profilesManagerMock,
-      resetDefaultProfileState: {
-        columns: true,
-        rowHeight: false,
-        breakdownField: false,
-      },
-      defaultColumns: ['messsage', 'bytes'],
-      dataView: dataViewWithTimefieldMock,
-      esqlQueryColumns: undefined,
-    });
-    expect(appState).toEqual({
-      columns: ['message', 'extension', 'bytes'],
-      grid: {
-        columns: {
-          extension: {
-            width: 200,
-          },
-          message: {
-            width: 100,
-          },
-        },
-      },
-    });
-    appState = getDefaultProfileState({
-      profilesManager: profilesManagerMock,
-      resetDefaultProfileState: {
-        columns: true,
-        rowHeight: false,
-        breakdownField: false,
-      },
-      defaultColumns: ['messsage', 'bytes'],
-      dataView: emptyDataView,
-      esqlQueryColumns: [
-        { id: '1', name: 'foo', meta: { type: 'string' } },
-        { id: '2', name: 'bar', meta: { type: 'string' } },
-      ],
-    });
-    expect(appState).toEqual({
-      columns: ['foo', 'bar'],
-      grid: {
-        columns: {
-          foo: {
-            width: 300,
-          },
-        },
-      },
-    });
-  });
-
-  it('should return expected rowHeight', () => {
-    const appState = getDefaultProfileState({
-      profilesManager: profilesManagerMock,
-      resetDefaultProfileState: {
-        columns: false,
-        rowHeight: true,
-        breakdownField: false,
-      },
-      defaultColumns: [],
-      dataView: dataViewWithTimefieldMock,
-      esqlQueryColumns: undefined,
-    });
-    expect(appState).toEqual({
-      rowHeight: 3,
-    });
-  });
-
-  it('should return expected breakdownField', () => {
-    const appState = getDefaultProfileState({
-      profilesManager: profilesManagerMock,
-      resetDefaultProfileState: {
-        columns: false,
-        rowHeight: false,
-        breakdownField: true,
-      },
-      defaultColumns: [],
-      dataView: dataViewWithTimefieldMock,
-      esqlQueryColumns: undefined,
-    });
-    expect(appState).toEqual({
-      breakdownField: 'breakdown.field',
-    });
-  });
-
-  it('should return undefined', () => {
-    const appState = getDefaultProfileState({
-      profilesManager: profilesManagerMock,
-      resetDefaultProfileState: {
-        columns: false,
-        rowHeight: false,
-        breakdownField: false,
-      },
-      defaultColumns: [],
-      dataView: dataViewWithTimefieldMock,
-      esqlQueryColumns: undefined,
-    });
-    expect(appState).toEqual(undefined);
-  });
+  it('temp', () => {});
 });
+
+// import { fieldList } from '@kbn/data-views-plugin/common';
+// import { buildDataViewMock } from '@kbn/discover-utils/src/__mocks__';
+// import { createContextAwarenessMocks } from '../../../../context_awareness/__mocks__';
+// import { dataViewWithTimefieldMock } from '../../../../__mocks__/data_view_with_timefield';
+// import { getDefaultProfileState } from './get_default_profile_state';
+
+// const emptyDataView = buildDataViewMock({
+//   name: 'emptyDataView',
+//   fields: fieldList(),
+// });
+// const { profilesManagerMock } = createContextAwarenessMocks();
+
+// profilesManagerMock.resolveDataSourceProfile({});
+
+// describe('getDefaultProfileState', () => {
+//   it('should return expected columns', () => {
+//     let appState = getDefaultProfileState({
+//       profilesManager: profilesManagerMock,
+//       resetDefaultProfileState: {
+//         columns: true,
+//         rowHeight: false,
+//         breakdownField: false,
+//       },
+//       defaultColumns: ['messsage', 'bytes'],
+//       dataView: dataViewWithTimefieldMock,
+//       esqlQueryColumns: undefined,
+//     });
+//     expect(appState).toEqual({
+//       columns: ['message', 'extension', 'bytes'],
+//       grid: {
+//         columns: {
+//           extension: {
+//             width: 200,
+//           },
+//           message: {
+//             width: 100,
+//           },
+//         },
+//       },
+//     });
+//     appState = getDefaultProfileState({
+//       profilesManager: profilesManagerMock,
+//       resetDefaultProfileState: {
+//         columns: true,
+//         rowHeight: false,
+//         breakdownField: false,
+//       },
+//       defaultColumns: ['messsage', 'bytes'],
+//       dataView: emptyDataView,
+//       esqlQueryColumns: [
+//         { id: '1', name: 'foo', meta: { type: 'string' } },
+//         { id: '2', name: 'bar', meta: { type: 'string' } },
+//       ],
+//     });
+//     expect(appState).toEqual({
+//       columns: ['foo', 'bar'],
+//       grid: {
+//         columns: {
+//           foo: {
+//             width: 300,
+//           },
+//         },
+//       },
+//     });
+//   });
+
+//   it('should return expected rowHeight', () => {
+//     const appState = getDefaultProfileState({
+//       profilesManager: profilesManagerMock,
+//       resetDefaultProfileState: {
+//         columns: false,
+//         rowHeight: true,
+//         breakdownField: false,
+//       },
+//       defaultColumns: [],
+//       dataView: dataViewWithTimefieldMock,
+//       esqlQueryColumns: undefined,
+//     });
+//     expect(appState).toEqual({
+//       rowHeight: 3,
+//     });
+//   });
+
+//   it('should return expected breakdownField', () => {
+//     const appState = getDefaultProfileState({
+//       profilesManager: profilesManagerMock,
+//       resetDefaultProfileState: {
+//         columns: false,
+//         rowHeight: false,
+//         breakdownField: true,
+//       },
+//       defaultColumns: [],
+//       dataView: dataViewWithTimefieldMock,
+//       esqlQueryColumns: undefined,
+//     });
+//     expect(appState).toEqual({
+//       breakdownField: 'breakdown.field',
+//     });
+//   });
+
+//   it('should return undefined', () => {
+//     const appState = getDefaultProfileState({
+//       profilesManager: profilesManagerMock,
+//       resetDefaultProfileState: {
+//         columns: false,
+//         rowHeight: false,
+//         breakdownField: false,
+//       },
+//       defaultColumns: [],
+//       dataView: dataViewWithTimefieldMock,
+//       esqlQueryColumns: undefined,
+//     });
+//     expect(appState).toEqual(undefined);
+//   });
+// });

--- a/src/plugins/discover/public/application/main/state_management/utils/get_default_profile_state.test.ts
+++ b/src/plugins/discover/public/application/main/state_management/utils/get_default_profile_state.test.ts
@@ -7,122 +7,134 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-describe('getDefaultProfileState', () => {
-  it('temp', () => {});
+import { fieldList } from '@kbn/data-views-plugin/common';
+import { buildDataViewMock } from '@kbn/discover-utils/src/__mocks__';
+import { createContextAwarenessMocks } from '../../../../context_awareness/__mocks__';
+import { dataViewWithTimefieldMock } from '../../../../__mocks__/data_view_with_timefield';
+import { getDefaultProfileState } from './get_default_profile_state';
+
+const emptyDataView = buildDataViewMock({
+  name: 'emptyDataView',
+  fields: fieldList(),
 });
+const { profilesManagerMock } = createContextAwarenessMocks();
 
-// import { fieldList } from '@kbn/data-views-plugin/common';
-// import { buildDataViewMock } from '@kbn/discover-utils/src/__mocks__';
-// import { createContextAwarenessMocks } from '../../../../context_awareness/__mocks__';
-// import { dataViewWithTimefieldMock } from '../../../../__mocks__/data_view_with_timefield';
-// import { getDefaultProfileState } from './get_default_profile_state';
+profilesManagerMock.resolveDataSourceProfile({});
 
-// const emptyDataView = buildDataViewMock({
-//   name: 'emptyDataView',
-//   fields: fieldList(),
-// });
-// const { profilesManagerMock } = createContextAwarenessMocks();
+describe('getDefaultProfileState', () => {
+  describe('getPreFetchState', () => {
+    it('should return expected breakdownField', () => {
+      let appState = getDefaultProfileState({
+        profilesManager: profilesManagerMock,
+        resetDefaultProfileState: {
+          columns: false,
+          rowHeight: false,
+          breakdownField: true,
+        },
+        dataView: dataViewWithTimefieldMock,
+      }).getPreFetchState();
+      expect(appState).toEqual({
+        breakdownField: 'extension',
+      });
+      appState = getDefaultProfileState({
+        profilesManager: profilesManagerMock,
+        resetDefaultProfileState: {
+          columns: false,
+          rowHeight: false,
+          breakdownField: true,
+        },
+        dataView: emptyDataView,
+      }).getPreFetchState();
+      expect(appState).toEqual(undefined);
+    });
+  });
 
-// profilesManagerMock.resolveDataSourceProfile({});
+  describe('getPostFetchState', () => {
+    it('should return expected columns', () => {
+      let appState = getDefaultProfileState({
+        profilesManager: profilesManagerMock,
+        resetDefaultProfileState: {
+          columns: true,
+          rowHeight: false,
+          breakdownField: false,
+        },
+        dataView: dataViewWithTimefieldMock,
+      }).getPostFetchState({
+        defaultColumns: ['messsage', 'bytes'],
+        esqlQueryColumns: undefined,
+      });
+      expect(appState).toEqual({
+        columns: ['message', 'extension', 'bytes'],
+        grid: {
+          columns: {
+            extension: {
+              width: 200,
+            },
+            message: {
+              width: 100,
+            },
+          },
+        },
+      });
+      appState = getDefaultProfileState({
+        profilesManager: profilesManagerMock,
+        resetDefaultProfileState: {
+          columns: true,
+          rowHeight: false,
+          breakdownField: false,
+        },
+        dataView: emptyDataView,
+      }).getPostFetchState({
+        defaultColumns: ['messsage', 'bytes'],
+        esqlQueryColumns: [
+          { id: '1', name: 'foo', meta: { type: 'string' } },
+          { id: '2', name: 'bar', meta: { type: 'string' } },
+        ],
+      });
+      expect(appState).toEqual({
+        columns: ['foo', 'bar'],
+        grid: {
+          columns: {
+            foo: {
+              width: 300,
+            },
+          },
+        },
+      });
+    });
 
-// describe('getDefaultProfileState', () => {
-//   it('should return expected columns', () => {
-//     let appState = getDefaultProfileState({
-//       profilesManager: profilesManagerMock,
-//       resetDefaultProfileState: {
-//         columns: true,
-//         rowHeight: false,
-//         breakdownField: false,
-//       },
-//       defaultColumns: ['messsage', 'bytes'],
-//       dataView: dataViewWithTimefieldMock,
-//       esqlQueryColumns: undefined,
-//     });
-//     expect(appState).toEqual({
-//       columns: ['message', 'extension', 'bytes'],
-//       grid: {
-//         columns: {
-//           extension: {
-//             width: 200,
-//           },
-//           message: {
-//             width: 100,
-//           },
-//         },
-//       },
-//     });
-//     appState = getDefaultProfileState({
-//       profilesManager: profilesManagerMock,
-//       resetDefaultProfileState: {
-//         columns: true,
-//         rowHeight: false,
-//         breakdownField: false,
-//       },
-//       defaultColumns: ['messsage', 'bytes'],
-//       dataView: emptyDataView,
-//       esqlQueryColumns: [
-//         { id: '1', name: 'foo', meta: { type: 'string' } },
-//         { id: '2', name: 'bar', meta: { type: 'string' } },
-//       ],
-//     });
-//     expect(appState).toEqual({
-//       columns: ['foo', 'bar'],
-//       grid: {
-//         columns: {
-//           foo: {
-//             width: 300,
-//           },
-//         },
-//       },
-//     });
-//   });
+    it('should return expected rowHeight', () => {
+      const appState = getDefaultProfileState({
+        profilesManager: profilesManagerMock,
+        resetDefaultProfileState: {
+          columns: false,
+          rowHeight: true,
+          breakdownField: false,
+        },
+        dataView: dataViewWithTimefieldMock,
+      }).getPostFetchState({
+        defaultColumns: [],
+        esqlQueryColumns: undefined,
+      });
+      expect(appState).toEqual({
+        rowHeight: 3,
+      });
+    });
 
-//   it('should return expected rowHeight', () => {
-//     const appState = getDefaultProfileState({
-//       profilesManager: profilesManagerMock,
-//       resetDefaultProfileState: {
-//         columns: false,
-//         rowHeight: true,
-//         breakdownField: false,
-//       },
-//       defaultColumns: [],
-//       dataView: dataViewWithTimefieldMock,
-//       esqlQueryColumns: undefined,
-//     });
-//     expect(appState).toEqual({
-//       rowHeight: 3,
-//     });
-//   });
-
-//   it('should return expected breakdownField', () => {
-//     const appState = getDefaultProfileState({
-//       profilesManager: profilesManagerMock,
-//       resetDefaultProfileState: {
-//         columns: false,
-//         rowHeight: false,
-//         breakdownField: true,
-//       },
-//       defaultColumns: [],
-//       dataView: dataViewWithTimefieldMock,
-//       esqlQueryColumns: undefined,
-//     });
-//     expect(appState).toEqual({
-//       breakdownField: 'breakdown.field',
-//     });
-//   });
-
-//   it('should return undefined', () => {
-//     const appState = getDefaultProfileState({
-//       profilesManager: profilesManagerMock,
-//       resetDefaultProfileState: {
-//         columns: false,
-//         rowHeight: false,
-//         breakdownField: false,
-//       },
-//       defaultColumns: [],
-//       dataView: dataViewWithTimefieldMock,
-//       esqlQueryColumns: undefined,
-//     });
-//     expect(appState).toEqual(undefined);
-//   });
-// });
+    it('should return undefined', () => {
+      const appState = getDefaultProfileState({
+        profilesManager: profilesManagerMock,
+        resetDefaultProfileState: {
+          columns: false,
+          rowHeight: false,
+          breakdownField: false,
+        },
+        dataView: dataViewWithTimefieldMock,
+      }).getPostFetchState({
+        defaultColumns: [],
+        esqlQueryColumns: undefined,
+      });
+      expect(appState).toEqual(undefined);
+    });
+  });
+});

--- a/src/plugins/discover/public/application/main/state_management/utils/get_default_profile_state.ts
+++ b/src/plugins/discover/public/application/main/state_management/utils/get_default_profile_state.ts
@@ -34,7 +34,11 @@ export const getDefaultProfileState = ({
     getPreFetchState: () => {
       const stateUpdate: DiscoverAppState = {};
 
-      if (resetDefaultProfileState.breakdownField && defaultState.breakdownField !== undefined) {
+      if (
+        resetDefaultProfileState.breakdownField &&
+        defaultState.breakdownField !== undefined &&
+        dataView.fields.getByName(defaultState.breakdownField)
+      ) {
         stateUpdate.breakdownField = defaultState.breakdownField;
       }
 

--- a/src/plugins/discover/public/application/main/state_management/utils/get_default_profile_state.ts
+++ b/src/plugins/discover/public/application/main/state_management/utils/get_default_profile_state.ts
@@ -31,6 +31,11 @@ export const getDefaultProfileState = ({
   const defaultState = getDefaultState(profilesManager, dataView);
 
   return {
+    /**
+     * Returns state that should be updated before data fetching occurs,
+     * for example state used as part of the data fetching process
+     * @returns The state to reset to before fetching data
+     */
     getPreFetchState: () => {
       const stateUpdate: DiscoverAppState = {};
 
@@ -44,6 +49,12 @@ export const getDefaultProfileState = ({
 
       return Object.keys(stateUpdate).length ? stateUpdate : undefined;
     },
+
+    /**
+     * Returns state that should be updated after data fetching occurs,
+     * for example state used to modify the UI after receiving data
+     * @returns The state to reset to after fetching data
+     */
     getPostFetchState: ({
       defaultColumns,
       esqlQueryColumns,

--- a/src/plugins/discover/public/context_awareness/__mocks__/index.tsx
+++ b/src/plugins/discover/public/context_awareness/__mocks__/index.tsx
@@ -84,7 +84,7 @@ export const createContextAwarenessMocks = ({
           },
         ],
         rowHeight: 3,
-        breakdownField: 'breakdown.field',
+        breakdownField: 'extension',
       })),
       getAdditionalCellActions: jest.fn((prev) => () => [
         ...prev(),

--- a/src/plugins/unified_histogram/public/container/container.tsx
+++ b/src/plugins/unified_histogram/public/container/container.tsx
@@ -95,7 +95,7 @@ export type UnifiedHistogramApi = {
 export const UnifiedHistogramContainer = forwardRef<
   UnifiedHistogramApi,
   UnifiedHistogramContainerProps
->(({ onBreakdownFieldChange, onVisContextChanged, ...containerProps }, ref) => {
+>(({ breakdownField, onBreakdownFieldChange, onVisContextChanged, ...containerProps }, ref) => {
   const [layoutProps, setLayoutProps] = useState<LayoutProps>();
   const [localStorageKeyPrefix, setLocalStorageKeyPrefix] = useState<string>();
   const [stateService, setStateService] = useState<UnifiedHistogramStateService>();
@@ -158,8 +158,7 @@ export const UnifiedHistogramContainer = forwardRef<
     searchSessionId,
     requestAdapter,
     columns,
-    breakdownField: initialBreakdownField,
-    ...pick(containerProps, 'breakdownField'),
+    breakdownField: breakdownField ?? initialBreakdownField,
     onBreakdownFieldChange,
   });
 

--- a/src/plugins/unified_histogram/public/container/container.tsx
+++ b/src/plugins/unified_histogram/public/container/container.tsx
@@ -95,7 +95,7 @@ export type UnifiedHistogramApi = {
 export const UnifiedHistogramContainer = forwardRef<
   UnifiedHistogramApi,
   UnifiedHistogramContainerProps
->(({ breakdownField, onBreakdownFieldChange, onVisContextChanged, ...containerProps }, ref) => {
+>(({ onBreakdownFieldChange, onVisContextChanged, ...containerProps }, ref) => {
   const [layoutProps, setLayoutProps] = useState<LayoutProps>();
   const [localStorageKeyPrefix, setLocalStorageKeyPrefix] = useState<string>();
   const [stateService, setStateService] = useState<UnifiedHistogramStateService>();
@@ -158,7 +158,8 @@ export const UnifiedHistogramContainer = forwardRef<
     searchSessionId,
     requestAdapter,
     columns,
-    breakdownField: breakdownField ?? initialBreakdownField,
+    breakdownField: initialBreakdownField,
+    ...pick(containerProps, 'breakdownField'),
     onBreakdownFieldChange,
   });
 

--- a/src/plugins/unified_histogram/public/container/container.tsx
+++ b/src/plugins/unified_histogram/public/container/container.tsx
@@ -28,6 +28,7 @@ import { useStateProps } from './hooks/use_state_props';
 import { useStateSelector } from './utils/use_state_selector';
 import { topPanelHeightSelector } from './utils/state_selectors';
 import { exportVisContext } from '../utils/external_vis_context';
+import { getBreakdownField } from './utils/local_storage_utils';
 
 type LayoutProps = Pick<
   UnifiedHistogramLayoutProps,
@@ -94,7 +95,7 @@ export type UnifiedHistogramApi = {
 export const UnifiedHistogramContainer = forwardRef<
   UnifiedHistogramApi,
   UnifiedHistogramContainerProps
->(({ breakdownField, onBreakdownFieldChange, onVisContextChanged, ...containerProps }, ref) => {
+>(({ onBreakdownFieldChange, onVisContextChanged, ...containerProps }, ref) => {
   const [layoutProps, setLayoutProps] = useState<LayoutProps>();
   const [localStorageKeyPrefix, setLocalStorageKeyPrefix] = useState<string>();
   const [stateService, setStateService] = useState<UnifiedHistogramStateService>();
@@ -141,6 +142,13 @@ export const UnifiedHistogramContainer = forwardRef<
   const { services, dataView, query, columns, searchSessionId, requestAdapter, isChartLoading } =
     containerProps;
   const topPanelHeight = useStateSelector(stateService?.state$, topPanelHeightSelector);
+  const initialBreakdownField = useMemo(
+    () =>
+      localStorageKeyPrefix
+        ? getBreakdownField(services.storage, localStorageKeyPrefix)
+        : undefined,
+    [localStorageKeyPrefix, services.storage]
+  );
   const stateProps = useStateProps({
     services,
     localStorageKeyPrefix,
@@ -150,7 +158,8 @@ export const UnifiedHistogramContainer = forwardRef<
     searchSessionId,
     requestAdapter,
     columns,
-    breakdownField,
+    breakdownField: initialBreakdownField,
+    ...pick(containerProps, 'breakdownField'),
     onBreakdownFieldChange,
   });
 

--- a/src/plugins/unified_histogram/public/container/hooks/use_state_props.test.ts
+++ b/src/plugins/unified_histogram/public/container/hooks/use_state_props.test.ts
@@ -27,7 +27,6 @@ import { useStateProps } from './use_state_props';
 
 describe('useStateProps', () => {
   const initialState: UnifiedHistogramState = {
-    breakdownField: 'bytes',
     chartHidden: false,
     lensRequestAdapter: new RequestAdapter(),
     lensAdapters: lensAdaptersMock,
@@ -45,7 +44,6 @@ describe('useStateProps', () => {
     });
     jest.spyOn(stateService, 'setChartHidden');
     jest.spyOn(stateService, 'setTopPanelHeight');
-    jest.spyOn(stateService, 'setBreakdownField');
     jest.spyOn(stateService, 'setTimeInterval');
     jest.spyOn(stateService, 'setLensRequestAdapter');
     jest.spyOn(stateService, 'setTotalHits');
@@ -57,25 +55,22 @@ describe('useStateProps', () => {
     const stateService = getStateService({ initialState });
     const { result } = renderHook(() =>
       useStateProps({
+        services: unifiedHistogramServicesMock,
+        localStorageKeyPrefix: undefined,
         stateService,
         dataView: dataViewWithTimefieldMock,
         query: { language: 'kuery', query: '' },
         requestAdapter: new RequestAdapter(),
         searchSessionId: '123',
         columns: undefined,
+        breakdownField: undefined,
+        onBreakdownFieldChange: undefined,
       })
     );
     expect(result.current).toMatchInlineSnapshot(`
       Object {
         "breakdown": Object {
-          "field": Object {
-            "aggregatable": true,
-            "displayName": "bytes",
-            "filterable": true,
-            "name": "bytes",
-            "scripted": false,
-            "type": "number",
-          },
+          "field": undefined,
         },
         "chart": Object {
           "hidden": false,
@@ -148,12 +143,16 @@ describe('useStateProps', () => {
     const stateService = getStateService({ initialState });
     const { result } = renderHook(() =>
       useStateProps({
+        services: unifiedHistogramServicesMock,
+        localStorageKeyPrefix: undefined,
         stateService,
         dataView: dataViewWithTimefieldMock,
         query: { esql: 'FROM index' },
         requestAdapter: new RequestAdapter(),
         searchSessionId: '123',
         columns: undefined,
+        breakdownField: undefined,
+        onBreakdownFieldChange: undefined,
       })
     );
     expect(result.current).toMatchInlineSnapshot(`
@@ -241,12 +240,16 @@ describe('useStateProps', () => {
     });
     const { result } = renderHook(() =>
       useStateProps({
+        services: unifiedHistogramServicesMock,
+        localStorageKeyPrefix: undefined,
         stateService,
         dataView: dataViewWithTimefieldMock,
         query: { esql: 'FROM index | keep field1' },
         requestAdapter: new RequestAdapter(),
         searchSessionId: '123',
         columns: undefined,
+        breakdownField: undefined,
+        onBreakdownFieldChange: undefined,
       })
     );
     expect(result.current.chart).toStrictEqual({ hidden: false, timeInterval: 'auto' });
@@ -272,17 +275,20 @@ describe('useStateProps', () => {
       initialState: {
         ...initialState,
         currentSuggestionContext: undefined,
-        breakdownField,
       },
     });
     const { result } = renderHook(() =>
       useStateProps({
+        services: unifiedHistogramServicesMock,
+        localStorageKeyPrefix: undefined,
         stateService,
         dataView: dataViewWithTimefieldMock,
         query: { esql: 'FROM index' },
         requestAdapter: new RequestAdapter(),
         searchSessionId: '123',
         columns: esqlColumns,
+        breakdownField,
+        onBreakdownFieldChange: undefined,
       })
     );
 
@@ -315,25 +321,30 @@ describe('useStateProps', () => {
     });
     const { result } = renderHook(() =>
       useStateProps({
+        services: unifiedHistogramServicesMock,
+        localStorageKeyPrefix: undefined,
         stateService,
         dataView: dataViewWithTimefieldMock,
         query: { esql: 'FROM index' },
         requestAdapter: new RequestAdapter(),
         searchSessionId: '123',
         columns: esqlColumns,
+        breakdownField: undefined,
+        onBreakdownFieldChange: undefined,
       })
     );
     const { onBreakdownFieldChange } = result.current;
     act(() => {
       onBreakdownFieldChange({ name: breakdownField } as DataViewField);
     });
-    expect(stateService.setBreakdownField).toHaveBeenLastCalledWith(breakdownField);
   });
 
   it('should return the correct props when a rollup data view is used', () => {
     const stateService = getStateService({ initialState });
     const { result } = renderHook(() =>
       useStateProps({
+        services: unifiedHistogramServicesMock,
+        localStorageKeyPrefix: undefined,
         stateService,
         dataView: {
           ...dataViewWithTimefieldMock,
@@ -343,6 +354,8 @@ describe('useStateProps', () => {
         requestAdapter: new RequestAdapter(),
         searchSessionId: '123',
         columns: undefined,
+        breakdownField: undefined,
+        onBreakdownFieldChange: undefined,
       })
     );
     expect(result.current).toMatchInlineSnapshot(`
@@ -416,12 +429,16 @@ describe('useStateProps', () => {
     const stateService = getStateService({ initialState });
     const { result } = renderHook(() =>
       useStateProps({
+        services: unifiedHistogramServicesMock,
+        localStorageKeyPrefix: undefined,
         stateService,
         dataView: dataViewMock,
         query: { language: 'kuery', query: '' },
         requestAdapter: new RequestAdapter(),
         searchSessionId: '123',
         columns: undefined,
+        breakdownField: undefined,
+        onBreakdownFieldChange: undefined,
       })
     );
     expect(result.current).toMatchInlineSnapshot(`
@@ -495,12 +512,16 @@ describe('useStateProps', () => {
     const stateService = getStateService({ initialState });
     const { result } = renderHook(() =>
       useStateProps({
+        services: unifiedHistogramServicesMock,
+        localStorageKeyPrefix: undefined,
         stateService,
         dataView: dataViewWithTimefieldMock,
         query: { language: 'kuery', query: '' },
         requestAdapter: new RequestAdapter(),
         searchSessionId: '123',
         columns: undefined,
+        breakdownField: undefined,
+        onBreakdownFieldChange: undefined,
       })
     );
     const {
@@ -539,8 +560,6 @@ describe('useStateProps', () => {
     act(() => {
       onBreakdownFieldChange({ name: 'field' } as DataViewField);
     });
-    expect(stateService.setBreakdownField).toHaveBeenLastCalledWith('field');
-
     act(() => {
       onSuggestionContextChange({
         suggestion: { title: 'Stacked Bar' },
@@ -555,12 +574,16 @@ describe('useStateProps', () => {
     const stateService = getStateService({ initialState });
     const hook = renderHook(() =>
       useStateProps({
+        services: unifiedHistogramServicesMock,
+        localStorageKeyPrefix: undefined,
         stateService,
         dataView: dataViewWithTimefieldMock,
         query: { language: 'kuery', query: '' },
         requestAdapter: new RequestAdapter(),
         searchSessionId: '123',
         columns: undefined,
+        breakdownField: undefined,
+        onBreakdownFieldChange: undefined,
       })
     );
     (stateService.setLensRequestAdapter as jest.Mock).mockClear();
@@ -575,12 +598,16 @@ describe('useStateProps', () => {
   it('should clear lensRequestAdapter when chart is undefined', () => {
     const stateService = getStateService({ initialState });
     const initialProps = {
+      services: unifiedHistogramServicesMock,
+      localStorageKeyPrefix: undefined,
       stateService,
       dataView: dataViewWithTimefieldMock,
       query: { language: 'kuery', query: '' },
       requestAdapter: new RequestAdapter(),
       searchSessionId: '123',
       columns: undefined,
+      breakdownField: undefined,
+      onBreakdownFieldChange: undefined,
     };
     const hook = renderHook((props: Parameters<typeof useStateProps>[0]) => useStateProps(props), {
       initialProps,

--- a/src/plugins/unified_histogram/public/container/hooks/use_state_props.ts
+++ b/src/plugins/unified_histogram/public/container/hooks/use_state_props.ts
@@ -17,11 +17,11 @@ import { useCallback, useEffect, useMemo } from 'react';
 import {
   UnifiedHistogramChartLoadEvent,
   UnifiedHistogramFetchStatus,
+  UnifiedHistogramServices,
   UnifiedHistogramSuggestionContext,
 } from '../../types';
 import type { UnifiedHistogramStateService } from '../services/state_service';
 import {
-  breakdownFieldSelector,
   chartHiddenSelector,
   timeIntervalSelector,
   totalHitsResultSelector,
@@ -30,23 +30,31 @@ import {
   lensEmbeddableOutputSelector$,
 } from '../utils/state_selectors';
 import { useStateSelector } from '../utils/use_state_selector';
+import { setBreakdownField } from '../utils/local_storage_utils';
 
 export const useStateProps = ({
+  services,
+  localStorageKeyPrefix,
   stateService,
   dataView,
   query,
   searchSessionId,
   requestAdapter,
   columns,
+  breakdownField,
+  onBreakdownFieldChange: originalOnBreakdownFieldChange,
 }: {
+  services: UnifiedHistogramServices;
+  localStorageKeyPrefix: string | undefined;
   stateService: UnifiedHistogramStateService | undefined;
   dataView: DataView;
   query: Query | AggregateQuery | undefined;
   searchSessionId: string | undefined;
   requestAdapter: RequestAdapter | undefined;
   columns: DatatableColumn[] | undefined;
+  breakdownField: string | undefined;
+  onBreakdownFieldChange: ((breakdownField: string | undefined) => void) | undefined;
 }) => {
-  const breakdownField = useStateSelector(stateService?.state$, breakdownFieldSelector);
   const chartHidden = useStateSelector(stateService?.state$, chartHiddenSelector);
   const timeInterval = useStateSelector(stateService?.state$, timeIntervalSelector);
   const totalHitsResult = useStateSelector(stateService?.state$, totalHitsResultSelector);
@@ -169,9 +177,9 @@ export const useStateProps = ({
 
   const onBreakdownFieldChange = useCallback(
     (newBreakdownField: DataViewField | undefined) => {
-      stateService?.setBreakdownField(newBreakdownField?.name);
+      originalOnBreakdownFieldChange?.(newBreakdownField?.name);
     },
-    [stateService]
+    [originalOnBreakdownFieldChange]
   );
 
   const onSuggestionContextChange = useCallback(
@@ -184,6 +192,13 @@ export const useStateProps = ({
   /**
    * Effects
    */
+
+  // Sync the breakdown field with local storage
+  useEffect(() => {
+    if (localStorageKeyPrefix) {
+      setBreakdownField(services.storage, localStorageKeyPrefix, breakdownField);
+    }
+  }, [breakdownField, localStorageKeyPrefix, services.storage]);
 
   // Clear the Lens request adapter when the chart is hidden
   useEffect(() => {

--- a/src/plugins/unified_histogram/public/container/hooks/use_state_props.ts
+++ b/src/plugins/unified_histogram/public/container/hooks/use_state_props.ts
@@ -64,6 +64,7 @@ export const useStateProps = ({
     stateService?.state$,
     lensEmbeddableOutputSelector$
   );
+
   /**
    * Contexts
    */

--- a/src/plugins/unified_histogram/public/container/services/state_service.test.ts
+++ b/src/plugins/unified_histogram/public/container/services/state_service.test.ts
@@ -14,10 +14,8 @@ import { lensAdaptersMock } from '../../__mocks__/lens_adapters';
 import {
   getChartHidden,
   getTopPanelHeight,
-  getBreakdownField,
   setChartHidden,
   setTopPanelHeight,
-  setBreakdownField,
 } from '../utils/local_storage_utils';
 import { createStateService, UnifiedHistogramState } from './state_service';
 
@@ -27,10 +25,8 @@ jest.mock('../utils/local_storage_utils', () => {
     ...originalModule,
     getChartHidden: jest.fn(originalModule.getChartHidden),
     getTopPanelHeight: jest.fn(originalModule.getTopPanelHeight),
-    getBreakdownField: jest.fn(originalModule.getBreakdownField),
     setChartHidden: jest.fn(originalModule.setChartHidden),
     setTopPanelHeight: jest.fn(originalModule.setTopPanelHeight),
-    setBreakdownField: jest.fn(originalModule.setBreakdownField),
   };
 });
 
@@ -38,14 +34,11 @@ describe('UnifiedHistogramStateService', () => {
   beforeEach(() => {
     (getChartHidden as jest.Mock).mockClear();
     (getTopPanelHeight as jest.Mock).mockClear();
-    (getBreakdownField as jest.Mock).mockClear();
     (setChartHidden as jest.Mock).mockClear();
     (setTopPanelHeight as jest.Mock).mockClear();
-    (setBreakdownField as jest.Mock).mockClear();
   });
 
   const initialState: UnifiedHistogramState = {
-    breakdownField: 'bytes',
     chartHidden: false,
     lensRequestAdapter: new RequestAdapter(),
     lensAdapters: lensAdaptersMock,
@@ -61,7 +54,6 @@ describe('UnifiedHistogramStateService', () => {
     let state: UnifiedHistogramState | undefined;
     stateService.state$.subscribe((s) => (state = s));
     expect(state).toEqual({
-      breakdownField: undefined,
       chartHidden: false,
       lensRequestAdapter: undefined,
       timeInterval: 'auto',
@@ -97,10 +89,6 @@ describe('UnifiedHistogramStateService', () => {
       unifiedHistogramServicesMock.storage,
       localStorageKeyPrefix
     );
-    expect(getBreakdownField as jest.Mock).toHaveBeenCalledWith(
-      unifiedHistogramServicesMock.storage,
-      localStorageKeyPrefix
-    );
   });
 
   it('should not get values from storage if localStorageKeyPrefix is not provided', () => {
@@ -110,7 +98,6 @@ describe('UnifiedHistogramStateService', () => {
     });
     expect(getChartHidden as jest.Mock).not.toHaveBeenCalled();
     expect(getTopPanelHeight as jest.Mock).not.toHaveBeenCalled();
-    expect(getBreakdownField as jest.Mock).not.toHaveBeenCalled();
   });
 
   it('should update state', () => {
@@ -127,9 +114,6 @@ describe('UnifiedHistogramStateService', () => {
     expect(state).toEqual(newState);
     stateService.setTopPanelHeight(200);
     newState = { ...newState, topPanelHeight: 200 };
-    expect(state).toEqual(newState);
-    stateService.setBreakdownField('test');
-    newState = { ...newState, breakdownField: 'test' };
     expect(state).toEqual(newState);
     stateService.setTimeInterval('test');
     newState = { ...newState, timeInterval: 'test' };
@@ -166,12 +150,10 @@ describe('UnifiedHistogramStateService', () => {
     expect(state).toEqual(initialState);
     stateService.setChartHidden(true);
     stateService.setTopPanelHeight(200);
-    stateService.setBreakdownField('test');
     expect(state).toEqual({
       ...initialState,
       chartHidden: true,
       topPanelHeight: 200,
-      breakdownField: 'test',
     });
     expect(setChartHidden as jest.Mock).toHaveBeenCalledWith(
       unifiedHistogramServicesMock.storage,
@@ -182,11 +164,6 @@ describe('UnifiedHistogramStateService', () => {
       unifiedHistogramServicesMock.storage,
       localStorageKeyPrefix,
       200
-    );
-    expect(setBreakdownField as jest.Mock).toHaveBeenCalledWith(
-      unifiedHistogramServicesMock.storage,
-      localStorageKeyPrefix,
-      'test'
     );
   });
 
@@ -200,15 +177,12 @@ describe('UnifiedHistogramStateService', () => {
     expect(state).toEqual(initialState);
     stateService.setChartHidden(true);
     stateService.setTopPanelHeight(200);
-    stateService.setBreakdownField('test');
     expect(state).toEqual({
       ...initialState,
       chartHidden: true,
       topPanelHeight: 200,
-      breakdownField: 'test',
     });
     expect(setChartHidden as jest.Mock).not.toHaveBeenCalled();
     expect(setTopPanelHeight as jest.Mock).not.toHaveBeenCalled();
-    expect(setBreakdownField as jest.Mock).not.toHaveBeenCalled();
   });
 });

--- a/src/plugins/unified_histogram/public/container/services/state_service.ts
+++ b/src/plugins/unified_histogram/public/container/services/state_service.ts
@@ -16,7 +16,6 @@ import {
   getBreakdownField,
   getChartHidden,
   getTopPanelHeight,
-  setBreakdownField,
   setChartHidden,
   setTopPanelHeight,
 } from '../utils/local_storage_utils';
@@ -26,10 +25,6 @@ import type { UnifiedHistogramSuggestionContext } from '../../types';
  * The current state of the container
  */
 export interface UnifiedHistogramState {
-  /**
-   * The current field used for the breakdown
-   */
-  breakdownField: string | undefined;
   /**
    * The current Lens suggestion
    */
@@ -109,10 +104,6 @@ export interface UnifiedHistogramStateService {
    */
   setTopPanelHeight: (topPanelHeight: number | undefined) => void;
   /**
-   * Sets the current breakdown field
-   */
-  setBreakdownField: (breakdownField: string | undefined) => void;
-  /**
    * Sets the current time interval
    */
   setTimeInterval: (timeInterval: string) => void;
@@ -152,7 +143,6 @@ export const createStateService = (
   }
 
   const state$ = new BehaviorSubject<UnifiedHistogramState>({
-    breakdownField: initialBreakdownField,
     chartHidden: initialChartHidden,
     currentSuggestionContext: undefined,
     lensRequestAdapter: undefined,
@@ -187,14 +177,6 @@ export const createStateService = (
       }
 
       updateState({ topPanelHeight });
-    },
-
-    setBreakdownField: (breakdownField: string | undefined) => {
-      if (localStorageKeyPrefix) {
-        setBreakdownField(services.storage, localStorageKeyPrefix, breakdownField);
-      }
-
-      updateState({ breakdownField });
     },
 
     setCurrentSuggestionContext: (

--- a/src/plugins/unified_histogram/public/container/services/state_service.ts
+++ b/src/plugins/unified_histogram/public/container/services/state_service.ts
@@ -13,7 +13,6 @@ import { BehaviorSubject, Observable } from 'rxjs';
 import { UnifiedHistogramFetchStatus } from '../..';
 import type { UnifiedHistogramServices, UnifiedHistogramChartLoadEvent } from '../../types';
 import {
-  getBreakdownField,
   getChartHidden,
   getTopPanelHeight,
   setChartHidden,
@@ -134,12 +133,10 @@ export const createStateService = (
 
   let initialChartHidden = false;
   let initialTopPanelHeight: number | undefined;
-  let initialBreakdownField: string | undefined;
 
   if (localStorageKeyPrefix) {
     initialChartHidden = getChartHidden(services.storage, localStorageKeyPrefix) ?? false;
     initialTopPanelHeight = getTopPanelHeight(services.storage, localStorageKeyPrefix);
-    initialBreakdownField = getBreakdownField(services.storage, localStorageKeyPrefix);
   }
 
   const state$ = new BehaviorSubject<UnifiedHistogramState>({

--- a/src/plugins/unified_histogram/public/container/utils/state_selectors.ts
+++ b/src/plugins/unified_histogram/public/container/utils/state_selectors.ts
@@ -9,7 +9,6 @@
 
 import type { UnifiedHistogramState } from '../services/state_service';
 
-export const breakdownFieldSelector = (state: UnifiedHistogramState) => state.breakdownField;
 export const chartHiddenSelector = (state: UnifiedHistogramState) => state.chartHidden;
 export const timeIntervalSelector = (state: UnifiedHistogramState) => state.timeInterval;
 export const topPanelHeightSelector = (state: UnifiedHistogramState) => state.topPanelHeight;

--- a/src/plugins/unified_histogram/public/mocks.ts
+++ b/src/plugins/unified_histogram/public/mocks.ts
@@ -15,7 +15,6 @@ export const createMockUnifiedHistogramApi = () => {
     state$: new Observable(),
     setChartHidden: jest.fn(),
     setTopPanelHeight: jest.fn(),
-    setBreakdownField: jest.fn(),
     setTimeInterval: jest.fn(),
     setTotalHits: jest.fn(),
     refetch: jest.fn(),


### PR DESCRIPTION
## Summary

This PR fixes support for `breakdownField` in `getDefaultAppState` to ensure it gets set when expected and does not trigger additional data fetching. It does this by splitting `getDefaultProfileState` into two phases: `getPreFetchState` and `getPostFetchState`, which apply default state before and after data fetching respectively.

There are also some related changes to make this work, mainly around Discover's (complicated) state management, and ES|QL mode special handling. I also had to change the way Unified Histogram receives the `breakdownField` since the current approach was causing a race condition (all the more reason to improve and refactor Unified Histogram).